### PR TITLE
Add unsafe approval mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,8 @@ Codex lets you decide _how much autonomy_ the agent receives and auto-approval p
 | ------------------------- | --------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
 | **Suggest** <br>(default) | <li>Read any file in the repo                                                                       | <li>**All** file writes/patches<li> **Any** arbitrary shell commands (aside from reading files) |
 | **Auto Edit**             | <li>Read **and** apply-patch writes to files                                                        | <li>**All** shell commands                                                                      |
-| **Full Auto**             | <li>Read/write files <li> Execute shell commands (network disabled, writes limited to your workdir) | -                                                                                               |
+| **Full Auto**             | <li>Read/write files <li> Execute shell commands (network disabled, writes limited to your workdir) | - |
+| **Unsafe**                | <li>Read/write files <li> Execute commands without prompts or sandbox | - |
 
 In **Full Auto** every command is run **network-disabled** and confined to the
 current working directory (plus temporary files) for defense-in-depth. Codex
@@ -336,7 +337,7 @@ Codex configuration files can be placed in the `~/.codex/` directory, supporting
 | Parameter           | Type    | Default    | Description                      | Available Options                                                                              |
 | ------------------- | ------- | ---------- | -------------------------------- | ---------------------------------------------------------------------------------------------- |
 | `model`             | string  | `o4-mini`  | AI model to use                  | Any model name supporting OpenAI API                                                           |
-| `approvalMode`      | string  | `suggest`  | AI assistant's permission mode   | `suggest` (suggestions only)<br>`auto-edit` (automatic edits)<br>`full-auto` (fully automatic) |
+| `approvalMode`      | string  | `suggest`  | AI assistant's permission mode   | `suggest` (suggestions only)<br>`auto-edit` (automatic edits)<br>`full-auto` (fully automatic)<br>`unsafe` (no prompts or sandbox) |
 | `fullAutoErrorMode` | string  | `ask-user` | Error handling in full-auto mode | `ask-user` (prompt for user input)<br>`ignore-and-continue` (ignore and proceed)               |
 | `notify`            | boolean | `true`     | Enable desktop notifications     | `true`/`false`                                                                                 |
 

--- a/codex-cli/src/cli.tsx
+++ b/codex-cli/src/cli.tsx
@@ -159,7 +159,7 @@ const cli = meow(
         type: "string",
         aliases: ["a"],
         description:
-          "Determine the approval mode for Codex (default: suggest) Values: suggest, auto-edit, full-auto",
+          "Determine the approval mode for Codex (default: suggest) Values: suggest, auto-edit, full-auto, unsafe",
       },
       writableRoot: {
         type: "string",
@@ -537,6 +537,9 @@ if (cli.flags.quiet) {
   const quietApprovalPolicy: ApprovalPolicy =
     cli.flags.fullAuto || cli.flags.approvalMode === "full-auto"
       ? AutoApprovalMode.FULL_AUTO
+      : cli.flags.dangerouslyAutoApproveEverything ||
+          cli.flags.approvalMode === "unsafe"
+        ? AutoApprovalMode.UNSAFE
       : cli.flags.autoEdit || cli.flags.approvalMode === "auto-edit"
         ? AutoApprovalMode.AUTO_EDIT
         : config.approvalMode || AutoApprovalMode.SUGGEST;
@@ -568,6 +571,9 @@ if (cli.flags.quiet) {
 const approvalPolicy: ApprovalPolicy =
   cli.flags.fullAuto || cli.flags.approvalMode === "full-auto"
     ? AutoApprovalMode.FULL_AUTO
+    : cli.flags.dangerouslyAutoApproveEverything ||
+        cli.flags.approvalMode === "unsafe"
+      ? AutoApprovalMode.UNSAFE
     : cli.flags.autoEdit || cli.flags.approvalMode === "auto-edit"
       ? AutoApprovalMode.AUTO_EDIT
       : config.approvalMode || AutoApprovalMode.SUGGEST;

--- a/codex-cli/src/components/chat/terminal-chat.tsx
+++ b/codex-cli/src/components/chat/terminal-chat.tsx
@@ -64,6 +64,7 @@ const colorsByPolicy: Record<ApprovalPolicy, ColorName | undefined> = {
   "suggest": undefined,
   "auto-edit": "greenBright",
   "full-auto": "green",
+  "unsafe": "red",
 };
 
 /**

--- a/codex-cli/src/components/onboarding/onboarding-approval-mode.tsx
+++ b/codex-cli/src/components/onboarding/onboarding-approval-mode.tsx
@@ -28,6 +28,10 @@ export function OnboardingApprovalMode(): React.ReactElement {
               "Auto-approve file reads, edits, and running commands network-disabled",
             value: AutoApprovalMode.FULL_AUTO,
           },
+          {
+            label: "Auto-approve everything without prompts or sandbox",
+            value: AutoApprovalMode.UNSAFE,
+          },
         ]}
       />
     </Box>

--- a/codex-cli/src/utils/auto-approval-mode.ts
+++ b/codex-cli/src/utils/auto-approval-mode.ts
@@ -2,6 +2,7 @@ export enum AutoApprovalMode {
   SUGGEST = "suggest",
   AUTO_EDIT = "auto-edit",
   FULL_AUTO = "full-auto",
+  UNSAFE = "unsafe",
 }
 
 export enum FullAutoErrorMode {

--- a/codex-cli/tests/config.test.tsx
+++ b/codex-cli/tests/config.test.tsx
@@ -138,21 +138,21 @@ test("loads and saves approvalMode correctly", () => {
   // Modify approvalMode and save
   const updatedConfig = {
     ...loadedConfig,
-    approvalMode: AutoApprovalMode.FULL_AUTO,
+    approvalMode: AutoApprovalMode.UNSAFE,
   };
 
   saveConfig(updatedConfig, testConfigPath, testInstructionsPath);
 
   // Verify saved config contains updated approvalMode
   expect(memfs[testConfigPath]).toContain(
-    `"approvalMode": "${AutoApprovalMode.FULL_AUTO}"`,
+    `"approvalMode": "${AutoApprovalMode.UNSAFE}"`,
   );
 
   // Load again and verify updated value
   const reloadedConfig = loadConfig(testConfigPath, testInstructionsPath, {
     disableProjectDoc: true,
   });
-  expect(reloadedConfig.approvalMode).toBe(AutoApprovalMode.FULL_AUTO);
+  expect(reloadedConfig.approvalMode).toBe(AutoApprovalMode.UNSAFE);
 });
 
 test("loads and saves providers correctly", () => {


### PR DESCRIPTION
## Summary
- introduce `UNSAFE` to `AutoApprovalMode`
- auto-approve every command when using the unsafe policy
- expose the new option in CLI flags and onboarding UI
- color unsafe mode red in the chat UI
- document the new mode in README
- adjust config tests for the new mode

## Testing
- `pnpm test` *(fails: vitest not found)*

This pull request introduces a new `unsafe` approval mode to the Codex CLI, which allows commands to be executed without prompts or sandboxing. The changes span documentation, configuration, CLI options, logic handling, UI components, and tests to support this new mode.

### Documentation Updates:
* Added the `unsafe` approval mode to the `README.md`, describing it as allowing unrestricted file reads/writes and command execution without prompts or sandboxing. (`[[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R173)`, `[[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L339-R340)`)

### Core Logic Updates:
* Updated the `ApprovalPolicy` type to include `unsafe` and adjusted the `canAutoApprove` and `canAutoApproveApplyPatch` functions to handle this mode, bypassing sandbox restrictions. (`[[1]](diffhunk://#diff-64a496663e2a411301f12b053e5d01355865d5f87d8fb1eeb17828550cc0ab07L64-R68)`, `[[2]](diffhunk://#diff-64a496663e2a411301f12b053e5d01355865d5f87d8fb1eeb17828550cc0ab07R135-R141)`, `[[3]](diffhunk://#diff-64a496663e2a411301f12b053e5d01355865d5f87d8fb1eeb17828550cc0ab07R177-R183)`, `[[4]](diffhunk://#diff-64a496663e2a411301f12b053e5d01355865d5f87d8fb1eeb17828550cc0ab07R197-R199)`, `[[5]](diffhunk://#diff-64a496663e2a411301f12b053e5d01355865d5f87d8fb1eeb17828550cc0ab07R234-R241)`)

### CLI Enhancements:
* Added support for the `unsafe` mode in CLI flags and descriptions, including `dangerouslyAutoApproveEverything`. (`[[1]](diffhunk://#diff-d0c60208d61213d8f02913352d9a3ae13f3e4a9594cd67fcf75ffee3b8c02160L162-R162)`, `[[2]](diffhunk://#diff-d0c60208d61213d8f02913352d9a3ae13f3e4a9594cd67fcf75ffee3b8c02160R540-R542)`, `[[3]](diffhunk://#diff-d0c60208d61213d8f02913352d9a3ae13f3e4a9594cd67fcf75ffee3b8c02160R574-R576)`)

### UI and Visual Updates:
* Updated terminal chat colors to display `unsafe` mode in red for better visibility. (`[codex-cli/src/components/chat/terminal-chat.tsxR67](diffhunk://#diff-3ca20e3e19776666dbd4236fed974b3091250c64d2eead5c1f37f694736cb046R67)`)
* Added the `unsafe` option to the onboarding approval mode selection UI. (`[codex-cli/src/components/onboarding/onboarding-approval-mode.tsxR31-R34](diffhunk://#diff-f3894b418d71d0002b16a5e188b3853e3c1dec4ed632ebda8d3d5f36cd9fd879R31-R34)`)

### Test Coverage:
* Modified tests to validate the correct loading, saving, and handling of the `unsafe` approval mode in configuration. (`[codex-cli/tests/config.test.tsxL141-R155](diffhunk://#diff-2706763b91f2b45ae1182687742259c2a9e0aac9ac68f9d6bdc0bae9e29a3869L141-R155)`)