### PR TITLE
Rebase off Codex

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 # enable 'universe' because musl-tools & clang live there
@@ -11,20 +11,17 @@ RUN apt-get update && \
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     build-essential curl git ca-certificates \
-    pkg-config clang musl-tools libssl-dev && \
+    pkg-config clang musl-tools libssl-dev just && \
     rm -rf /var/lib/apt/lists/*
 
-# non-root dev user
-ARG USER=dev
-ARG UID=1000
-RUN useradd -m -u $UID $USER
-USER $USER
+# Ubuntu 24.04 ships with user 'ubuntu' already created with UID 1000.
+USER ubuntu
 
 # install Rust + musl target as dev user
 RUN curl -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal && \
     ~/.cargo/bin/rustup target add aarch64-unknown-linux-musl && \
     ~/.cargo/bin/rustup component add clippy rustfmt
 
-ENV PATH="/home/${USER}/.cargo/bin:${PATH}"
+ENV PATH="/home/ubuntu/.cargo/bin:${PATH}"
 
 WORKDIR /workspace

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -22,7 +22,8 @@ USER $USER
 
 # install Rust + musl target as dev user
 RUN curl -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal && \
-    ~/.cargo/bin/rustup target add aarch64-unknown-linux-musl
+    ~/.cargo/bin/rustup target add aarch64-unknown-linux-musl && \
+    ~/.cargo/bin/rustup component add clippy rustfmt
 
 ENV PATH="/home/${USER}/.cargo/bin:${PATH}"
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,15 +15,13 @@
     "CARGO_TARGET_DIR": "${containerWorkspaceFolder}/codex-rs/target-arm64"
   },
 
-  "remoteUser": "dev",
+  "remoteUser": "ubuntu",
   "customizations": {
     "vscode": {
       "settings": {
-          "terminal.integrated.defaultProfile.linux": "bash"
+        "terminal.integrated.defaultProfile.linux": "bash"
       },
-      "extensions": [
-          "rust-lang.rust-analyzer"
-      ],
+      "extensions": ["rust-lang.rust-analyzer"]
     }
   }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,12 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: pnpm stage-release
 
-      - name: Ensure README.md contains only ASCII and certain Unicode code points
+      - name: Ensure root README.md contains only ASCII and certain Unicode code points
         run: ./scripts/asciicheck.py README.md
-      - name: Check README ToC
+      - name: Check root README ToC
         run: python3 scripts/readme_toc.py README.md
+
+      - name: Ensure codex-cli/README.md contains only ASCII and certain Unicode code points
+        run: ./scripts/asciicheck.py codex-cli/README.md
+      - name: Check codex-cli/README ToC
+        run: python3 scripts/readme_toc.py codex-cli/README.md

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -157,9 +157,7 @@ jobs:
   release:
     needs: build
     name: release
-    runs-on: ubuntu-24.04
-    env:
-      RELEASE_TAG: codex-rs-${{ github.sha }}-${{ github.run_attempt }}-${{ github.ref_name }}
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/download-artifact@v4
@@ -169,9 +167,19 @@ jobs:
       - name: List
         run: ls -R dist/
 
-      - uses: softprops/action-gh-release@v2
+      - name: Define release name
+        id: release_name
+        run: |
+          # Extract the version from the tag name, which is in the format
+          # "rust-v0.1.0".
+          version="${GITHUB_REF_NAME#rust-v}"
+          echo "name=${version}" >> $GITHUB_OUTPUT
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ env.RELEASE_TAG }}
+          name: ${{ steps.release_name.outputs.name }}
+          tag_name: ${{ github.ref_name }}
           files: dist/**
           # For now, tag releases as "prerelease" because we are not claiming
           # the Rust CLI is stable yet.
@@ -181,5 +189,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag: ${{ env.RELEASE_TAG }}
+          tag: ${{ github.ref_name }}
           config: .github/dotslash-config.json

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -15,9 +15,6 @@ concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true
 
-env:
-  TAG_REGEX: '^rust-v[0-9]+\.[0-9]+\.[0-9]+$'
-
 jobs:
   tag-check:
     runs-on: ubuntu-latest
@@ -33,8 +30,8 @@ jobs:
           # 1. Must be a tag and match the regex
           [[ "${GITHUB_REF_TYPE}" == "tag" ]] \
             || { echo "❌  Not a tag push"; exit 1; }
-          [[ "${GITHUB_REF_NAME}" =~ ${TAG_REGEX} ]] \
-            || { echo "❌  Tag '${GITHUB_REF_NAME}' != ${TAG_REGEX}"; exit 1; }
+          [[ "${GITHUB_REF_NAME}" =~ ^rust-v[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta)(\.[0-9]+)?)?$ ]] \
+            || { echo "❌  Tag '${GITHUB_REF_NAME}' doesn't match expected format"; exit 1; }
 
           # 2. Extract versions
           tag_ver="${GITHUB_REF_NAME#rust-v}"

--- a/README.md
+++ b/README.md
@@ -469,7 +469,7 @@ export OPENAI_API_KEY="your-api-key-here"
 
 # Azure OpenAI
 export AZURE_OPENAI_API_KEY="your-azure-api-key-here"
-export AZURE_OPENAI_API_VERSION="2025-03-01-preview" (Optional)
+export AZURE_OPENAI_API_VERSION="2025-04-01-preview" (Optional)
 
 # OpenRouter
 export OPENROUTER_API_KEY="your-openrouter-key-here"

--- a/codex-cli/README.md
+++ b/codex-cli/README.md
@@ -1,0 +1,736 @@
+<h1 align="center">OpenAI Codex CLI</h1>
+<p align="center">Lightweight coding agent that runs in your terminal</p>
+
+<p align="center"><code>npm i -g @openai/codex</code></p>
+
+> [!IMPORTANT]
+> This is the documentation for the _legacy_ TypeScript implementation of the Codex CLI. It has been superseded by the _Rust_ implementation. See the [README in the root of the Codex repository](https://github.com/openai/codex/blob/main/README.md) for details.
+
+![Codex demo GIF using: codex "explain this codebase to me"](../.github/demo.gif)
+
+---
+
+<details>
+<summary><strong>Table of contents</strong></summary>
+
+<!-- Begin ToC -->
+
+- [Experimental technology disclaimer](#experimental-technology-disclaimer)
+- [Quickstart](#quickstart)
+- [Why Codex?](#why-codex)
+- [Security model & permissions](#security-model--permissions)
+  - [Platform sandboxing details](#platform-sandboxing-details)
+- [System requirements](#system-requirements)
+- [CLI reference](#cli-reference)
+- [Memory & project docs](#memory--project-docs)
+- [Non-interactive / CI mode](#non-interactive--ci-mode)
+- [Tracing / verbose logging](#tracing--verbose-logging)
+- [Recipes](#recipes)
+- [Installation](#installation)
+- [Configuration guide](#configuration-guide)
+  - [Basic configuration parameters](#basic-configuration-parameters)
+  - [Custom AI provider configuration](#custom-ai-provider-configuration)
+  - [History configuration](#history-configuration)
+  - [Configuration examples](#configuration-examples)
+  - [Full configuration example](#full-configuration-example)
+  - [Custom instructions](#custom-instructions)
+  - [Environment variables setup](#environment-variables-setup)
+- [FAQ](#faq)
+- [Zero data retention (ZDR) usage](#zero-data-retention-zdr-usage)
+- [Codex open source fund](#codex-open-source-fund)
+- [Contributing](#contributing)
+  - [Development workflow](#development-workflow)
+  - [Git hooks with Husky](#git-hooks-with-husky)
+  - [Debugging](#debugging)
+  - [Writing high-impact code changes](#writing-high-impact-code-changes)
+  - [Opening a pull request](#opening-a-pull-request)
+  - [Review process](#review-process)
+  - [Community values](#community-values)
+  - [Getting help](#getting-help)
+  - [Contributor license agreement (CLA)](#contributor-license-agreement-cla)
+    - [Quick fixes](#quick-fixes)
+  - [Releasing `codex`](#releasing-codex)
+  - [Alternative build options](#alternative-build-options)
+    - [Nix flake development](#nix-flake-development)
+- [Security & responsible AI](#security--responsible-ai)
+- [License](#license)
+
+<!-- End ToC -->
+
+</details>
+
+---
+
+## Experimental technology disclaimer
+
+Codex CLI is an experimental project under active development. It is not yet stable, may contain bugs, incomplete features, or undergo breaking changes. We're building it in the open with the community and welcome:
+
+- Bug reports
+- Feature requests
+- Pull requests
+- Good vibes
+
+Help us improve by filing issues or submitting PRs (see the section below for how to contribute)!
+
+## Quickstart
+
+Install globally:
+
+```shell
+npm install -g @openai/codex
+```
+
+Next, set your OpenAI API key as an environment variable:
+
+```shell
+export OPENAI_API_KEY="your-api-key-here"
+```
+
+> **Note:** This command sets the key only for your current terminal session. You can add the `export` line to your shell's configuration file (e.g., `~/.zshrc`) but we recommend setting for the session. **Tip:** You can also place your API key into a `.env` file at the root of your project:
+>
+> ```env
+> OPENAI_API_KEY=your-api-key-here
+> ```
+>
+> The CLI will automatically load variables from `.env` (via `dotenv/config`).
+
+<details>
+<summary><strong>Use <code>--provider</code> to use other models</strong></summary>
+
+> Codex also allows you to use other providers that support the OpenAI Chat Completions API. You can set the provider in the config file or use the `--provider` flag. The possible options for `--provider` are:
+>
+> - openai (default)
+> - openrouter
+> - azure
+> - gemini
+> - ollama
+> - mistral
+> - deepseek
+> - xai
+> - groq
+> - arceeai
+> - any other provider that is compatible with the OpenAI API
+>
+> If you use a provider other than OpenAI, you will need to set the API key for the provider in the config file or in the environment variable as:
+>
+> ```shell
+> export <provider>_API_KEY="your-api-key-here"
+> ```
+>
+> If you use a provider not listed above, you must also set the base URL for the provider:
+>
+> ```shell
+> export <provider>_BASE_URL="https://your-provider-api-base-url"
+> ```
+
+</details>
+<br />
+
+Run interactively:
+
+```shell
+codex
+```
+
+Or, run with a prompt as input (and optionally in `Full Auto` mode):
+
+```shell
+codex "explain this codebase to me"
+```
+
+```shell
+codex --approval-mode full-auto "create the fanciest todo-list app"
+```
+
+That's it - Codex will scaffold a file, run it inside a sandbox, install any
+missing dependencies, and show you the live result. Approve the changes and
+they'll be committed to your working directory.
+
+---
+
+## Why Codex?
+
+Codex CLI is built for developers who already **live in the terminal** and want
+ChatGPT-level reasoning **plus** the power to actually run code, manipulate
+files, and iterate - all under version control. In short, it's _chat-driven
+development_ that understands and executes your repo.
+
+- **Zero setup** - bring your OpenAI API key and it just works!
+- **Full auto-approval, while safe + secure** by running network-disabled and directory-sandboxed
+- **Multimodal** - pass in screenshots or diagrams to implement features ✨
+
+And it's **fully open-source** so you can see and contribute to how it develops!
+
+---
+
+## Security model & permissions
+
+Codex lets you decide _how much autonomy_ the agent receives and auto-approval policy via the
+`--approval-mode` flag (or the interactive onboarding prompt):
+
+| Mode                      | What the agent may do without asking                                                                | Still requires approval                                                                         |
+| ------------------------- | --------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| **Suggest** <br>(default) | <li>Read any file in the repo                                                                       | <li>**All** file writes/patches<li> **Any** arbitrary shell commands (aside from reading files) |
+| **Auto Edit**             | <li>Read **and** apply-patch writes to files                                                        | <li>**All** shell commands                                                                      |
+| **Full Auto**             | <li>Read/write files <li> Execute shell commands (network disabled, writes limited to your workdir) | -                                                                                               |
+
+In **Full Auto** every command is run **network-disabled** and confined to the
+current working directory (plus temporary files) for defense-in-depth. Codex
+will also show a warning/confirmation if you start in **auto-edit** or
+**full-auto** while the directory is _not_ tracked by Git, so you always have a
+safety net.
+
+Coming soon: you'll be able to whitelist specific commands to auto-execute with
+the network enabled, once we're confident in additional safeguards.
+
+### Platform sandboxing details
+
+The hardening mechanism Codex uses depends on your OS:
+
+- **macOS 12+** - commands are wrapped with **Apple Seatbelt** (`sandbox-exec`).
+
+  - Everything is placed in a read-only jail except for a small set of
+    writable roots (`$PWD`, `$TMPDIR`, `~/.codex`, etc.).
+  - Outbound network is _fully blocked_ by default - even if a child process
+    tries to `curl` somewhere it will fail.
+
+- **Linux** - there is no sandboxing by default.
+  We recommend using Docker for sandboxing, where Codex launches itself inside a **minimal
+  container image** and mounts your repo _read/write_ at the same path. A
+  custom `iptables`/`ipset` firewall script denies all egress except the
+  OpenAI API. This gives you deterministic, reproducible runs without needing
+  root on the host. You can use the [`run_in_container.sh`](../codex-cli/scripts/run_in_container.sh) script to set up the sandbox.
+
+---
+
+## System requirements
+
+| Requirement                 | Details                                                         |
+| --------------------------- | --------------------------------------------------------------- |
+| Operating systems           | macOS 12+, Ubuntu 20.04+/Debian 10+, or Windows 11 **via WSL2** |
+| Node.js                     | **22 or newer** (LTS recommended)                               |
+| Git (optional, recommended) | 2.23+ for built-in PR helpers                                   |
+| RAM                         | 4-GB minimum (8-GB recommended)                                 |
+
+> Never run `sudo npm install -g`; fix npm permissions instead.
+
+---
+
+## CLI reference
+
+| Command                              | Purpose                             | Example                              |
+| ------------------------------------ | ----------------------------------- | ------------------------------------ |
+| `codex`                              | Interactive REPL                    | `codex`                              |
+| `codex "..."`                        | Initial prompt for interactive REPL | `codex "fix lint errors"`            |
+| `codex -q "..."`                     | Non-interactive "quiet mode"        | `codex -q --json "explain utils.ts"` |
+| `codex completion <bash\|zsh\|fish>` | Print shell completion script       | `codex completion bash`              |
+
+Key flags: `--model/-m`, `--approval-mode/-a`, `--quiet/-q`, and `--notify`.
+
+---
+
+## Memory & project docs
+
+You can give Codex extra instructions and guidance using `AGENTS.md` files. Codex looks for `AGENTS.md` files in the following places, and merges them top-down:
+
+1. `~/.codex/AGENTS.md` - personal global guidance
+2. `AGENTS.md` at repo root - shared project notes
+3. `AGENTS.md` in the current working directory - sub-folder/feature specifics
+
+Disable loading of these files with `--no-project-doc` or the environment variable `CODEX_DISABLE_PROJECT_DOC=1`.
+
+---
+
+## Non-interactive / CI mode
+
+Run Codex head-less in pipelines. Example GitHub Action step:
+
+```yaml
+- name: Update changelog via Codex
+  run: |
+    npm install -g @openai/codex
+    export OPENAI_API_KEY="${{ secrets.OPENAI_KEY }}"
+    codex -a auto-edit --quiet "update CHANGELOG for next release"
+```
+
+Set `CODEX_QUIET_MODE=1` to silence interactive UI noise.
+
+## Tracing / verbose logging
+
+Setting the environment variable `DEBUG=true` prints full API request and response details:
+
+```shell
+DEBUG=true codex
+```
+
+---
+
+## Recipes
+
+Below are a few bite-size examples you can copy-paste. Replace the text in quotes with your own task. See the [prompting guide](https://github.com/openai/codex/blob/main/codex-cli/examples/prompting_guide.md) for more tips and usage patterns.
+
+| ✨  | What you type                                                                   | What happens                                                               |
+| --- | ------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| 1   | `codex "Refactor the Dashboard component to React Hooks"`                       | Codex rewrites the class component, runs `npm test`, and shows the diff.   |
+| 2   | `codex "Generate SQL migrations for adding a users table"`                      | Infers your ORM, creates migration files, and runs them in a sandboxed DB. |
+| 3   | `codex "Write unit tests for utils/date.ts"`                                    | Generates tests, executes them, and iterates until they pass.              |
+| 4   | `codex "Bulk-rename *.jpeg -> *.jpg with git mv"`                               | Safely renames files and updates imports/usages.                           |
+| 5   | `codex "Explain what this regex does: ^(?=.*[A-Z]).{8,}$"`                      | Outputs a step-by-step human explanation.                                  |
+| 6   | `codex "Carefully review this repo, and propose 3 high impact well-scoped PRs"` | Suggests impactful PRs in the current codebase.                            |
+| 7   | `codex "Look for vulnerabilities and create a security review report"`          | Finds and explains security bugs.                                          |
+
+---
+
+## Installation
+
+<details open>
+<summary><strong>From npm (Recommended)</strong></summary>
+
+```bash
+npm install -g @openai/codex
+# or
+yarn global add @openai/codex
+# or
+bun install -g @openai/codex
+# or
+pnpm add -g @openai/codex
+```
+
+</details>
+
+<details>
+<summary><strong>Build from source</strong></summary>
+
+```bash
+# Clone the repository and navigate to the CLI package
+git clone https://github.com/openai/codex.git
+cd codex/codex-cli
+
+# Enable corepack
+corepack enable
+
+# Install dependencies and build
+pnpm install
+pnpm build
+
+# Linux-only: download prebuilt sandboxing binaries (requires gh and zstd).
+./scripts/install_native_deps.sh
+
+# Get the usage and the options
+node ./dist/cli.js --help
+
+# Run the locally-built CLI directly
+node ./dist/cli.js
+
+# Or link the command globally for convenience
+pnpm link
+```
+
+</details>
+
+---
+
+## Configuration guide
+
+Codex configuration files can be placed in the `~/.codex/` directory, supporting both YAML and JSON formats.
+
+### Basic configuration parameters
+
+| Parameter           | Type    | Default    | Description                      | Available Options                                                                              |
+| ------------------- | ------- | ---------- | -------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `model`             | string  | `o4-mini`  | AI model to use                  | Any model name supporting OpenAI API                                                           |
+| `approvalMode`      | string  | `suggest`  | AI assistant's permission mode   | `suggest` (suggestions only)<br>`auto-edit` (automatic edits)<br>`full-auto` (fully automatic) |
+| `fullAutoErrorMode` | string  | `ask-user` | Error handling in full-auto mode | `ask-user` (prompt for user input)<br>`ignore-and-continue` (ignore and proceed)               |
+| `notify`            | boolean | `true`     | Enable desktop notifications     | `true`/`false`                                                                                 |
+
+### Custom AI provider configuration
+
+In the `providers` object, you can configure multiple AI service providers. Each provider requires the following parameters:
+
+| Parameter | Type   | Description                             | Example                       |
+| --------- | ------ | --------------------------------------- | ----------------------------- |
+| `name`    | string | Display name of the provider            | `"OpenAI"`                    |
+| `baseURL` | string | API service URL                         | `"https://api.openai.com/v1"` |
+| `envKey`  | string | Environment variable name (for API key) | `"OPENAI_API_KEY"`            |
+
+### History configuration
+
+In the `history` object, you can configure conversation history settings:
+
+| Parameter           | Type    | Description                                            | Example Value |
+| ------------------- | ------- | ------------------------------------------------------ | ------------- |
+| `maxSize`           | number  | Maximum number of history entries to save              | `1000`        |
+| `saveHistory`       | boolean | Whether to save history                                | `true`        |
+| `sensitivePatterns` | array   | Patterns of sensitive information to filter in history | `[]`          |
+
+### Configuration examples
+
+1. YAML format (save as `~/.codex/config.yaml`):
+
+```yaml
+model: o4-mini
+approvalMode: suggest
+fullAutoErrorMode: ask-user
+notify: true
+```
+
+2. JSON format (save as `~/.codex/config.json`):
+
+```json
+{
+  "model": "o4-mini",
+  "approvalMode": "suggest",
+  "fullAutoErrorMode": "ask-user",
+  "notify": true
+}
+```
+
+### Full configuration example
+
+Below is a comprehensive example of `config.json` with multiple custom providers:
+
+```json
+{
+  "model": "o4-mini",
+  "provider": "openai",
+  "providers": {
+    "openai": {
+      "name": "OpenAI",
+      "baseURL": "https://api.openai.com/v1",
+      "envKey": "OPENAI_API_KEY"
+    },
+    "azure": {
+      "name": "AzureOpenAI",
+      "baseURL": "https://YOUR_PROJECT_NAME.openai.azure.com/openai",
+      "envKey": "AZURE_OPENAI_API_KEY"
+    },
+    "openrouter": {
+      "name": "OpenRouter",
+      "baseURL": "https://openrouter.ai/api/v1",
+      "envKey": "OPENROUTER_API_KEY"
+    },
+    "gemini": {
+      "name": "Gemini",
+      "baseURL": "https://generativelanguage.googleapis.com/v1beta/openai",
+      "envKey": "GEMINI_API_KEY"
+    },
+    "ollama": {
+      "name": "Ollama",
+      "baseURL": "http://localhost:11434/v1",
+      "envKey": "OLLAMA_API_KEY"
+    },
+    "mistral": {
+      "name": "Mistral",
+      "baseURL": "https://api.mistral.ai/v1",
+      "envKey": "MISTRAL_API_KEY"
+    },
+    "deepseek": {
+      "name": "DeepSeek",
+      "baseURL": "https://api.deepseek.com",
+      "envKey": "DEEPSEEK_API_KEY"
+    },
+    "xai": {
+      "name": "xAI",
+      "baseURL": "https://api.x.ai/v1",
+      "envKey": "XAI_API_KEY"
+    },
+    "groq": {
+      "name": "Groq",
+      "baseURL": "https://api.groq.com/openai/v1",
+      "envKey": "GROQ_API_KEY"
+    },
+    "arceeai": {
+      "name": "ArceeAI",
+      "baseURL": "https://conductor.arcee.ai/v1",
+      "envKey": "ARCEEAI_API_KEY"
+    }
+  },
+  "history": {
+    "maxSize": 1000,
+    "saveHistory": true,
+    "sensitivePatterns": []
+  }
+}
+```
+
+### Custom instructions
+
+You can create a `~/.codex/AGENTS.md` file to define custom guidance for the agent:
+
+```markdown
+- Always respond with emojis
+- Only use git commands when explicitly requested
+```
+
+### Environment variables setup
+
+For each AI provider, you need to set the corresponding API key in your environment variables. For example:
+
+```bash
+# OpenAI
+export OPENAI_API_KEY="your-api-key-here"
+
+# Azure OpenAI
+export AZURE_OPENAI_API_KEY="your-azure-api-key-here"
+export AZURE_OPENAI_API_VERSION="2025-04-01-preview" (Optional)
+
+# OpenRouter
+export OPENROUTER_API_KEY="your-openrouter-key-here"
+
+# Similarly for other providers
+```
+
+---
+
+## FAQ
+
+<details>
+<summary>OpenAI released a model called Codex in 2021 - is this related?</summary>
+
+In 2021, OpenAI released Codex, an AI system designed to generate code from natural language prompts. That original Codex model was deprecated as of March 2023 and is separate from the CLI tool.
+
+</details>
+
+<details>
+<summary>Which models are supported?</summary>
+
+Any model available with [Responses API](https://platform.openai.com/docs/api-reference/responses). The default is `o4-mini`, but pass `--model gpt-4.1` or set `model: gpt-4.1` in your config file to override.
+
+</details>
+<details>
+<summary>Why does <code>o3</code> or <code>o4-mini</code> not work for me?</summary>
+
+It's possible that your [API account needs to be verified](https://help.openai.com/en/articles/10910291-api-organization-verification) in order to start streaming responses and seeing chain of thought summaries from the API. If you're still running into issues, please let us know!
+
+</details>
+
+<details>
+<summary>How do I stop Codex from editing my files?</summary>
+
+Codex runs model-generated commands in a sandbox. If a proposed command or file change doesn't look right, you can simply type **n** to deny the command or give the model feedback.
+
+</details>
+<details>
+<summary>Does it work on Windows?</summary>
+
+Not directly. It requires [Windows Subsystem for Linux (WSL2)](https://learn.microsoft.com/en-us/windows/wsl/install) - Codex has been tested on macOS and Linux with Node 22.
+
+</details>
+
+---
+
+## Zero data retention (ZDR) usage
+
+Codex CLI **does** support OpenAI organizations with [Zero Data Retention (ZDR)](https://platform.openai.com/docs/guides/your-data#zero-data-retention) enabled. If your OpenAI organization has Zero Data Retention enabled and you still encounter errors such as:
+
+```
+OpenAI rejected the request. Error details: Status: 400, Code: unsupported_parameter, Type: invalid_request_error, Message: 400 Previous response cannot be used for this organization due to Zero Data Retention.
+```
+
+You may need to upgrade to a more recent version with: `npm i -g @openai/codex@latest`
+
+---
+
+## Codex open source fund
+
+We're excited to launch a **$1 million initiative** supporting open source projects that use Codex CLI and other OpenAI models.
+
+- Grants are awarded up to **$25,000** API credits.
+- Applications are reviewed **on a rolling basis**.
+
+**Interested? [Apply here](https://openai.com/form/codex-open-source-fund/).**
+
+---
+
+## Contributing
+
+This project is under active development and the code will likely change pretty significantly. We'll update this message once that's complete!
+
+More broadly we welcome contributions - whether you are opening your very first pull request or you're a seasoned maintainer. At the same time we care about reliability and long-term maintainability, so the bar for merging code is intentionally **high**. The guidelines below spell out what "high-quality" means in practice and should make the whole process transparent and friendly.
+
+### Development workflow
+
+- Create a _topic branch_ from `main` - e.g. `feat/interactive-prompt`.
+- Keep your changes focused. Multiple unrelated fixes should be opened as separate PRs.
+- Use `pnpm test:watch` during development for super-fast feedback.
+- We use **Vitest** for unit tests, **ESLint** + **Prettier** for style, and **TypeScript** for type-checking.
+- Before pushing, run the full test/type/lint suite:
+
+### Git hooks with Husky
+
+This project uses [Husky](https://typicode.github.io/husky/) to enforce code quality checks:
+
+- **Pre-commit hook**: Automatically runs lint-staged to format and lint files before committing
+- **Pre-push hook**: Runs tests and type checking before pushing to the remote
+
+These hooks help maintain code quality and prevent pushing code with failing tests. For more details, see [HUSKY.md](./HUSKY.md).
+
+```bash
+pnpm test && pnpm run lint && pnpm run typecheck
+```
+
+- If you have **not** yet signed the Contributor License Agreement (CLA), add a PR comment containing the exact text
+
+  ```text
+  I have read the CLA Document and I hereby sign the CLA
+  ```
+
+  The CLA-Assistant bot will turn the PR status green once all authors have signed.
+
+```bash
+# Watch mode (tests rerun on change)
+pnpm test:watch
+
+# Type-check without emitting files
+pnpm typecheck
+
+# Automatically fix lint + prettier issues
+pnpm lint:fix
+pnpm format:fix
+```
+
+### Debugging
+
+To debug the CLI with a visual debugger, do the following in the `codex-cli` folder:
+
+- Run `pnpm run build` to build the CLI, which will generate `cli.js.map` alongside `cli.js` in the `dist` folder.
+- Run the CLI with `node --inspect-brk ./dist/cli.js` The program then waits until a debugger is attached before proceeding. Options:
+  - In VS Code, choose **Debug: Attach to Node Process** from the command palette and choose the option in the dropdown with debug port `9229` (likely the first option)
+  - Go to <chrome://inspect> in Chrome and find **localhost:9229** and click **trace**
+
+### Writing high-impact code changes
+
+1. **Start with an issue.** Open a new one or comment on an existing discussion so we can agree on the solution before code is written.
+2. **Add or update tests.** Every new feature or bug-fix should come with test coverage that fails before your change and passes afterwards. 100% coverage is not required, but aim for meaningful assertions.
+3. **Document behaviour.** If your change affects user-facing behaviour, update the README, inline help (`codex --help`), or relevant example projects.
+4. **Keep commits atomic.** Each commit should compile and the tests should pass. This makes reviews and potential rollbacks easier.
+
+### Opening a pull request
+
+- Fill in the PR template (or include similar information) - **What? Why? How?**
+- Run **all** checks locally (`npm test && npm run lint && npm run typecheck`). CI failures that could have been caught locally slow down the process.
+- Make sure your branch is up-to-date with `main` and that you have resolved merge conflicts.
+- Mark the PR as **Ready for review** only when you believe it is in a merge-able state.
+
+### Review process
+
+1. One maintainer will be assigned as a primary reviewer.
+2. We may ask for changes - please do not take this personally. We value the work, we just also value consistency and long-term maintainability.
+3. When there is consensus that the PR meets the bar, a maintainer will squash-and-merge.
+
+### Community values
+
+- **Be kind and inclusive.** Treat others with respect; we follow the [Contributor Covenant](https://www.contributor-covenant.org/).
+- **Assume good intent.** Written communication is hard - err on the side of generosity.
+- **Teach & learn.** If you spot something confusing, open an issue or PR with improvements.
+
+### Getting help
+
+If you run into problems setting up the project, would like feedback on an idea, or just want to say _hi_ - please open a Discussion or jump into the relevant issue. We are happy to help.
+
+Together we can make Codex CLI an incredible tool. **Happy hacking!** :rocket:
+
+### Contributor license agreement (CLA)
+
+All contributors **must** accept the CLA. The process is lightweight:
+
+1. Open your pull request.
+2. Paste the following comment (or reply `recheck` if you've signed before):
+
+   ```text
+   I have read the CLA Document and I hereby sign the CLA
+   ```
+
+3. The CLA-Assistant bot records your signature in the repo and marks the status check as passed.
+
+No special Git commands, email attachments, or commit footers required.
+
+#### Quick fixes
+
+| Scenario          | Command                                          |
+| ----------------- | ------------------------------------------------ |
+| Amend last commit | `git commit --amend -s --no-edit && git push -f` |
+
+The **DCO check** blocks merges until every commit in the PR carries the footer (with squash this is just the one).
+
+### Releasing `codex`
+
+To publish a new version of the CLI you first need to stage the npm package. A
+helper script in `codex-cli/scripts/` does all the heavy lifting. Inside the
+`codex-cli` folder run:
+
+```bash
+# Classic, JS implementation that includes small, native binaries for Linux sandboxing.
+pnpm stage-release
+
+# Optionally specify the temp directory to reuse between runs.
+RELEASE_DIR=$(mktemp -d)
+pnpm stage-release --tmp "$RELEASE_DIR"
+
+# "Fat" package that additionally bundles the native Rust CLI binaries for
+# Linux. End-users can then opt-in at runtime by setting CODEX_RUST=1.
+pnpm stage-release --native
+```
+
+Go to the folder where the release is staged and verify that it works as intended. If so, run the following from the temp folder:
+
+```
+cd "$RELEASE_DIR"
+npm publish
+```
+
+### Alternative build options
+
+#### Nix flake development
+
+Prerequisite: Nix >= 2.4 with flakes enabled (`experimental-features = nix-command flakes` in `~/.config/nix/nix.conf`).
+
+Enter a Nix development shell:
+
+```bash
+# Use either one of the commands according to which implementation you want to work with
+nix develop .#codex-cli # For entering codex-cli specific shell
+nix develop .#codex-rs # For entering codex-rs specific shell
+```
+
+This shell includes Node.js, installs dependencies, builds the CLI, and provides a `codex` command alias.
+
+Build and run the CLI directly:
+
+```bash
+# Use either one of the commands according to which implementation you want to work with
+nix build .#codex-cli # For building codex-cli
+nix build .#codex-rs # For building codex-rs
+./result/bin/codex --help
+```
+
+Run the CLI via the flake app:
+
+```bash
+# Use either one of the commands according to which implementation you want to work with
+nix run .#codex-cli # For running codex-cli
+nix run .#codex-rs # For running codex-rs
+```
+
+Use direnv with flakes
+
+If you have direnv installed, you can use the following `.envrc` to automatically enter the Nix shell when you `cd` into the project directory:
+
+```bash
+cd codex-rs
+echo "use flake ../flake.nix#codex-cli" >> .envrc && direnv allow
+cd codex-cli
+echo "use flake ../flake.nix#codex-rs" >> .envrc && direnv allow
+```
+
+---
+
+## Security & responsible AI
+
+Have you discovered a vulnerability or have concerns about model output? Please e-mail **security@openai.com** and we will respond promptly.
+
+---
+
+## License
+
+This repository is licensed under the [Apache-2.0 License](LICENSE).

--- a/codex-cli/src/cli.tsx
+++ b/codex-cli/src/cli.tsx
@@ -45,6 +45,7 @@ import { createInputItem } from "./utils/input-utils";
 import { initLogger } from "./utils/logger/log";
 import { isModelSupportedForResponses } from "./utils/model-utils.js";
 import { parseToolCall } from "./utils/parsers";
+import { providers } from "./utils/providers";
 import { onExit, setInkRenderer } from "./utils/terminal";
 import chalk from "chalk";
 import { spawnSync } from "child_process";
@@ -327,26 +328,44 @@ try {
   // ignore errors
 }
 
-if (cli.flags.login) {
-  apiKey = await fetchApiKey(client.issuer, client.client_id);
-  try {
-    const home = os.homedir();
-    const authDir = path.join(home, ".codex");
-    const authFile = path.join(authDir, "auth.json");
-    if (fs.existsSync(authFile)) {
-      const data = JSON.parse(fs.readFileSync(authFile, "utf-8"));
-      savedTokens = data.tokens;
+// Get provider-specific API key if not OpenAI
+if (provider.toLowerCase() !== "openai") {
+  const providerInfo = providers[provider.toLowerCase()];
+  if (providerInfo) {
+    const providerApiKey = process.env[providerInfo.envKey];
+    if (providerApiKey) {
+      apiKey = providerApiKey;
     }
-  } catch {
-    /* ignore */
   }
-} else if (!apiKey) {
-  apiKey = await fetchApiKey(client.issuer, client.client_id);
 }
+
+// Only proceed with OpenAI auth flow if:
+// 1. Provider is OpenAI and no API key is set, or
+// 2. Login flag is explicitly set
+if (provider.toLowerCase() === "openai" && !apiKey) {
+  if (cli.flags.login) {
+    apiKey = await fetchApiKey(client.issuer, client.client_id);
+    try {
+      const home = os.homedir();
+      const authDir = path.join(home, ".codex");
+      const authFile = path.join(authDir, "auth.json");
+      if (fs.existsSync(authFile)) {
+        const data = JSON.parse(fs.readFileSync(authFile, "utf-8"));
+        savedTokens = data.tokens;
+      }
+    } catch {
+      /* ignore */
+    }
+  } else {
+    apiKey = await fetchApiKey(client.issuer, client.client_id);
+  }
+}
+
 // Ensure the API key is available as an environment variable for legacy code
 process.env["OPENAI_API_KEY"] = apiKey;
 
-if (cli.flags.free) {
+// Only attempt credit redemption for OpenAI provider
+if (cli.flags.free && provider.toLowerCase() === "openai") {
   // eslint-disable-next-line no-console
   console.log(`${chalk.bold("codex --free")} attempting to redeem credits...`);
   if (!savedTokens?.refresh_token) {
@@ -379,13 +398,18 @@ if (!apiKey && !NO_API_KEY_REQUIRED.has(provider.toLowerCase())) {
           ? `You can create a key here: ${chalk.bold(
               chalk.underline("https://platform.openai.com/account/api-keys"),
             )}\n`
-          : provider.toLowerCase() === "gemini"
+          : provider.toLowerCase() === "azure"
             ? `You can create a ${chalk.bold(
-                `${provider.toUpperCase()}_API_KEY`,
-              )} ` + `in the ${chalk.bold(`Google AI Studio`)}.\n`
-            : `You can create a ${chalk.bold(
-                `${provider.toUpperCase()}_API_KEY`,
-              )} ` + `in the ${chalk.bold(`${provider}`)} dashboard.\n`
+                `${provider.toUpperCase()}_OPENAI_API_KEY`,
+              )} ` +
+              `in Azure AI Foundry portal at ${chalk.bold(chalk.underline("https://ai.azure.com"))}.\n`
+            : provider.toLowerCase() === "gemini"
+              ? `You can create a ${chalk.bold(
+                  `${provider.toUpperCase()}_API_KEY`,
+                )} ` + `in the ${chalk.bold(`Google AI Studio`)}.\n`
+              : `You can create a ${chalk.bold(
+                  `${provider.toUpperCase()}_API_KEY`,
+                )} ` + `in the ${chalk.bold(`${provider}`)} dashboard.\n`
       }`,
   );
   process.exit(1);

--- a/codex-cli/src/utils/agent/agent-loop.ts
+++ b/codex-cli/src/utils/agent/agent-loop.ts
@@ -800,7 +800,8 @@ export class AgentLoop {
 
             const responseCall =
               !this.config.provider ||
-              this.config.provider?.toLowerCase() === "openai"
+              this.config.provider?.toLowerCase() === "openai" ||
+              this.config.provider?.toLowerCase() === "azure"
                 ? (params: ResponseCreateParams) =>
                     this.oai.responses.create(params)
                 : (params: ResponseCreateParams) =>
@@ -1188,7 +1189,8 @@ export class AgentLoop {
 
               const responseCall =
                 !this.config.provider ||
-                this.config.provider?.toLowerCase() === "openai"
+                this.config.provider?.toLowerCase() === "openai" ||
+                this.config.provider?.toLowerCase() === "azure"
                   ? (params: ResponseCreateParams) =>
                       this.oai.responses.create(params)
                   : (params: ResponseCreateParams) =>

--- a/codex-cli/src/utils/config.ts
+++ b/codex-cli/src/utils/config.ts
@@ -69,7 +69,7 @@ export const OPENAI_BASE_URL = process.env["OPENAI_BASE_URL"] || "";
 export let OPENAI_API_KEY = process.env["OPENAI_API_KEY"] || "";
 
 export const AZURE_OPENAI_API_VERSION =
-  process.env["AZURE_OPENAI_API_VERSION"] || "2025-03-01-preview";
+  process.env["AZURE_OPENAI_API_VERSION"] || "2025-04-01-preview";
 
 export const DEFAULT_REASONING_EFFORT = "high";
 export const OPENAI_ORGANIZATION = process.env["OPENAI_ORGANIZATION"] || "";

--- a/codex-cli/tests/agent-azure-responses-endpoint.test.ts
+++ b/codex-cli/tests/agent-azure-responses-endpoint.test.ts
@@ -1,0 +1,107 @@
+/**
+ * tests/agent-azure-responses-endpoint.test.ts
+ *
+ * Verifies that AgentLoop calls the `/responses` endpoint when provider is set to Azure.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Fake stream that yields a completed response event
+class FakeStream {
+  async *[Symbol.asyncIterator]() {
+    yield {
+      type: "response.completed",
+      response: { id: "azure_resp", status: "completed", output: [] },
+    } as any;
+  }
+}
+
+let lastCreateParams: any = null;
+
+vi.mock("openai", () => {
+  class FakeDefaultClient {
+    public responses = {
+      create: async (params: any) => {
+        lastCreateParams = params;
+        return new FakeStream();
+      },
+    };
+  }
+  class FakeAzureClient {
+    public responses = {
+      create: async (params: any) => {
+        lastCreateParams = params;
+        return new FakeStream();
+      },
+    };
+  }
+  class APIConnectionTimeoutError extends Error {}
+  return {
+    __esModule: true,
+    default: FakeDefaultClient,
+    AzureOpenAI: FakeAzureClient,
+    APIConnectionTimeoutError,
+  };
+});
+
+// Stub approvals to bypass command approval logic
+vi.mock("../src/approvals.js", () => ({
+  __esModule: true,
+  alwaysApprovedCommands: new Set<string>(),
+  canAutoApprove: () => ({ type: "auto-approve", runInSandbox: false }),
+  isSafeCommand: () => null,
+}));
+
+// Stub format-command to avoid formatting side effects
+vi.mock("../src/format-command.js", () => ({
+  __esModule: true,
+  formatCommandForDisplay: (cmd: Array<string>) => cmd.join(" "),
+}));
+
+// Stub internal logging to keep output clean
+vi.mock("../src/utils/agent/log.js", () => ({
+  __esModule: true,
+  log: () => {},
+  isLoggingEnabled: () => false,
+}));
+
+import { AgentLoop } from "../src/utils/agent/agent-loop.js";
+
+describe("AgentLoop Azure provider responses endpoint", () => {
+  beforeEach(() => {
+    lastCreateParams = null;
+  });
+
+  it("calls the /responses endpoint when provider is azure", async () => {
+    const cfg: any = {
+      model: "test-model",
+      provider: "azure",
+      instructions: "",
+      disableResponseStorage: false,
+      notify: false,
+    };
+    const loop = new AgentLoop({
+      additionalWritableRoots: [],
+      model: cfg.model,
+      config: cfg,
+      instructions: cfg.instructions,
+      approvalPolicy: { mode: "suggest" } as any,
+      onItem: () => {},
+      onLoading: () => {},
+      getCommandConfirmation: async () => ({ review: "yes" }) as any,
+      onLastResponseId: () => {},
+    });
+
+    await loop.run([
+      {
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: "hello" }],
+      },
+    ]);
+
+    expect(lastCreateParams).not.toBeNull();
+    expect(lastCreateParams.model).toBe(cfg.model);
+    expect(Array.isArray(lastCreateParams.input)).toBe(true);
+  });
+});

--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -699,6 +699,7 @@ dependencies = [
  "clap",
  "ignore",
  "nucleo-matcher",
+ "serde",
  "serde_json",
  "tokio",
 ]

--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -697,7 +697,6 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "clap",
- "codex-common",
  "codex-core",
  "landlock",
  "libc",

--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -770,6 +770,7 @@ dependencies = [
  "codex-ansi-escape",
  "codex-common",
  "codex-core",
+ "codex-file-search",
  "codex-linux-sandbox",
  "codex-login",
  "color-eyre",

--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -692,6 +692,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "codex-file-search"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "ignore",
+ "nucleo-matcher",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "codex-linux-sandbox"
 version = "0.0.0"
 dependencies = [
@@ -1602,6 +1614,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
+name = "globset"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a1028dfc5f5df5da8a56a73e6c153c9a9708ec57232470703592a3f18e49f5"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1983,6 +2008,22 @@ checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d89fd380afde86567dfba715db065673989d6253f42b88179abd3eae47bda4b"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata 0.4.9",
+ "same-file",
+ "walkdir",
+ "winapi-util",
 ]
 
 [[package]]
@@ -2575,6 +2616,16 @@ checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
  "winapi",
+]
+
+[[package]]
+name = "nucleo-matcher"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf33f538733d1a5a3494b836ba913207f14d9d4a1d3cd67030c5061bdd2cac85"
+dependencies = [
+ "memchr",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -4362,6 +4413,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",

--- a/codex-rs/Cargo.toml
+++ b/codex-rs/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "core",
     "exec",
     "execpolicy",
+    "file-search",
     "linux-sandbox",
     "login",
     "mcp-client",

--- a/codex-rs/Cargo.toml
+++ b/codex-rs/Cargo.toml
@@ -37,3 +37,6 @@ lto = "fat"
 # Because we bundle some of these executables with the TypeScript CLI, we
 # remove everything to make the binary as small as possible.
 strip = "symbols"
+
+# See https://github.com/openai/codex/issues/1411 for details.
+codegen-units = 1

--- a/codex-rs/cli/src/lib.rs
+++ b/codex-rs/cli/src/lib.rs
@@ -5,16 +5,12 @@ pub mod proto;
 
 use clap::Parser;
 use codex_common::CliConfigOverrides;
-use codex_common::SandboxPermissionOption;
 
 #[derive(Debug, Parser)]
 pub struct SeatbeltCommand {
     /// Convenience alias for low-friction sandboxed automatic execution (network-disabled sandbox that can write to cwd and TMPDIR)
     #[arg(long = "full-auto", default_value_t = false)]
     pub full_auto: bool,
-
-    #[clap(flatten)]
-    pub sandbox: SandboxPermissionOption,
 
     #[clap(skip)]
     pub config_overrides: CliConfigOverrides,
@@ -29,9 +25,6 @@ pub struct LandlockCommand {
     /// Convenience alias for low-friction sandboxed automatic execution (network-disabled sandbox that can write to cwd and TMPDIR)
     #[arg(long = "full-auto", default_value_t = false)]
     pub full_auto: bool,
-
-    #[clap(flatten)]
-    pub sandbox: SandboxPermissionOption,
 
     #[clap(skip)]
     pub config_overrides: CliConfigOverrides,

--- a/codex-rs/common/Cargo.toml
+++ b/codex-rs/common/Cargo.toml
@@ -16,3 +16,4 @@ serde = { version = "1", optional = true }
 # Separate feature so that `clap` is not a mandatory dependency.
 cli = ["clap", "toml", "serde"]
 elapsed = []
+sandbox_summary = []

--- a/codex-rs/common/src/approval_mode_cli_arg.rs
+++ b/codex-rs/common/src/approval_mode_cli_arg.rs
@@ -1,13 +1,9 @@
 //! Standard type to use with the `--approval-mode` CLI option.
 //! Available when the `cli` feature is enabled for the crate.
 
-use clap::ArgAction;
-use clap::Parser;
 use clap::ValueEnum;
 
-use codex_core::config::parse_sandbox_permission_with_base_path;
 use codex_core::protocol::AskForApproval;
-use codex_core::protocol::SandboxPermission;
 
 #[derive(Clone, Copy, Debug, ValueEnum)]
 #[value(rename_all = "kebab-case")]
@@ -35,39 +31,4 @@ impl From<ApprovalModeCliArg> for AskForApproval {
             ApprovalModeCliArg::Never => AskForApproval::Never,
         }
     }
-}
-
-#[derive(Parser, Debug)]
-pub struct SandboxPermissionOption {
-    /// Specify this flag multiple times to specify the full set of permissions
-    /// to grant to Codex.
-    ///
-    /// ```shell
-    /// codex -s disk-full-read-access \
-    ///       -s disk-write-cwd \
-    ///       -s disk-write-platform-user-temp-folder \
-    ///       -s disk-write-platform-global-temp-folder
-    /// ```
-    ///
-    /// Note disk-write-folder takes a value:
-    ///
-    /// ```shell
-    ///     -s disk-write-folder=$HOME/.pyenv/shims
-    /// ```
-    ///
-    /// These permissions are quite broad and should be used with caution:
-    ///
-    /// ```shell
-    ///     -s disk-full-write-access
-    ///     -s network-full-access
-    /// ```
-    #[arg(long = "sandbox-permission", short = 's', action = ArgAction::Append, value_parser = parse_sandbox_permission)]
-    pub permissions: Option<Vec<SandboxPermission>>,
-}
-
-/// Custom value-parser so we can keep the CLI surface small *and*
-/// still handle the parameterised `disk-write-folder` case.
-fn parse_sandbox_permission(raw: &str) -> std::io::Result<SandboxPermission> {
-    let base_path = std::env::current_dir()?;
-    parse_sandbox_permission_with_base_path(raw, base_path)
 }

--- a/codex-rs/common/src/approval_mode_cli_arg.rs
+++ b/codex-rs/common/src/approval_mode_cli_arg.rs
@@ -8,15 +8,15 @@ use codex_core::protocol::AskForApproval;
 #[derive(Clone, Copy, Debug, ValueEnum)]
 #[value(rename_all = "kebab-case")]
 pub enum ApprovalModeCliArg {
+    /// Only run "trusted" commands (e.g. ls, cat, sed) without asking for user
+    /// approval. Will escalate to the user if the model proposes a command that
+    /// is not in the "trusted" set.
+    Untrusted,
+
     /// Run all commands without asking for user approval.
     /// Only asks for approval if a command fails to execute, in which case it
     /// will escalate to the user to ask for un-sandboxed execution.
     OnFailure,
-
-    /// Only run "known safe" commands (e.g. ls, cat, sed) without
-    /// asking for user approval. Will escalate to the user if the model
-    /// proposes a command that is not allow-listed.
-    UnlessAllowListed,
 
     /// Never ask for user approval
     /// Execution failures are immediately returned to the model.
@@ -26,8 +26,8 @@ pub enum ApprovalModeCliArg {
 impl From<ApprovalModeCliArg> for AskForApproval {
     fn from(value: ApprovalModeCliArg) -> Self {
         match value {
+            ApprovalModeCliArg::Untrusted => AskForApproval::UnlessAllowListed,
             ApprovalModeCliArg::OnFailure => AskForApproval::OnFailure,
-            ApprovalModeCliArg::UnlessAllowListed => AskForApproval::UnlessAllowListed,
             ApprovalModeCliArg::Never => AskForApproval::Never,
         }
     }

--- a/codex-rs/common/src/approval_mode_cli_arg.rs
+++ b/codex-rs/common/src/approval_mode_cli_arg.rs
@@ -26,7 +26,7 @@ pub enum ApprovalModeCliArg {
 impl From<ApprovalModeCliArg> for AskForApproval {
     fn from(value: ApprovalModeCliArg) -> Self {
         match value {
-            ApprovalModeCliArg::Untrusted => AskForApproval::UnlessAllowListed,
+            ApprovalModeCliArg::Untrusted => AskForApproval::UnlessTrusted,
             ApprovalModeCliArg::OnFailure => AskForApproval::OnFailure,
             ApprovalModeCliArg::Never => AskForApproval::Never,
         }

--- a/codex-rs/common/src/lib.rs
+++ b/codex-rs/common/src/lib.rs
@@ -6,8 +6,6 @@ pub mod elapsed;
 
 #[cfg(feature = "cli")]
 pub use approval_mode_cli_arg::ApprovalModeCliArg;
-#[cfg(feature = "cli")]
-pub use approval_mode_cli_arg::SandboxPermissionOption;
 
 #[cfg(any(feature = "cli", test))]
 mod config_override;

--- a/codex-rs/common/src/lib.rs
+++ b/codex-rs/common/src/lib.rs
@@ -12,3 +12,8 @@ mod config_override;
 
 #[cfg(feature = "cli")]
 pub use config_override::CliConfigOverrides;
+
+mod sandbox_summary;
+
+#[cfg(feature = "sandbox_summary")]
+pub use sandbox_summary::summarize_sandbox_policy;

--- a/codex-rs/common/src/sandbox_summary.rs
+++ b/codex-rs/common/src/sandbox_summary.rs
@@ -1,0 +1,28 @@
+use codex_core::protocol::SandboxPolicy;
+
+pub fn summarize_sandbox_policy(sandbox_policy: &SandboxPolicy) -> String {
+    match sandbox_policy {
+        SandboxPolicy::DangerFullAccess => "danger-full-access".to_string(),
+        SandboxPolicy::ReadOnly => "read-only".to_string(),
+        SandboxPolicy::WorkspaceWrite {
+            writable_roots,
+            network_access,
+        } => {
+            let mut summary = "workspace-write".to_string();
+            if !writable_roots.is_empty() {
+                summary.push_str(&format!(
+                    " [{}]",
+                    writable_roots
+                        .iter()
+                        .map(|p| p.to_string_lossy())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ));
+            }
+            if *network_access {
+                summary.push_str(" (network access enabled)");
+            }
+            summary
+        }
+    }
+}

--- a/codex-rs/config.md
+++ b/codex-rs/config.md
@@ -41,8 +41,11 @@ base_url = "https://api.openai.com/v1"
 # using Codex with this provider. The value of the environment variable must be
 # non-empty and will be used in the `Bearer TOKEN` HTTP header for the POST request.
 env_key = "OPENAI_API_KEY"
-# Valid values for wire_api are "chat" and "responses".
+# Valid values for wire_api are "chat" and "responses". Defaults to "chat" if omitted.
 wire_api = "chat"
+# If necessary, extra query params that need to be added to the URL.
+# See the Azure example below.
+query_params = {}
 ```
 
 Note this makes it possible to use Codex CLI with non-OpenAI models, so long as they use a wire API that is compatible with the OpenAI chat completions API. For example, you could define the following provider to use Codex CLI with Ollama running locally:
@@ -51,7 +54,6 @@ Note this makes it possible to use Codex CLI with non-OpenAI models, so long as 
 [model_providers.ollama]
 name = "Ollama"
 base_url = "http://localhost:11434/v1"
-wire_api = "chat"
 ```
 
 Or a third-party provider (using a distinct environment variable for the API key):
@@ -61,7 +63,17 @@ Or a third-party provider (using a distinct environment variable for the API key
 name = "Mistral"
 base_url = "https://api.mistral.ai/v1"
 env_key = "MISTRAL_API_KEY"
-wire_api = "chat"
+```
+
+Note that Azure requires `api-version` to be passed as a query parameter, so be sure to specify it as part of `query_params` when defining the Azure provider:
+
+```toml
+[model_providers.azure]
+name = "Azure"
+# Make sure you set the appropriate subdomain for this URL.
+base_url = "https://YOUR_PROJECT_NAME.openai.azure.com/openai"
+env_key = "AZURE_OPENAI_API_KEY"  # Or "OPENAI_API_KEY", whichever you use.
+query_params = { api-version = "2025-04-01-preview" }
 ```
 
 ## model_provider

--- a/codex-rs/config.md
+++ b/codex-rs/config.md
@@ -20,41 +20,11 @@ The model that Codex should use.
 model = "o3"  # overrides the default of "codex-mini-latest"
 ```
 
-## model_provider
-
-Codex comes bundled with a number of "model providers" predefined. This config value is a string that indicates which provider to use. You can also define your own providers via `model_providers`.
-
-For example, if you are running ollama with Mistral locally, then you would need to add the following to your config:
-
-```toml
-model = "mistral"
-model_provider = "ollama"
-```
-
-because the following definition for `ollama` is included in Codex:
-
-```toml
-[model_providers.ollama]
-name = "Ollama"
-base_url = "http://localhost:11434/v1"
-wire_api = "chat"
-```
-
-This option defaults to `"openai"` and the corresponding provider is defined as follows:
-
-```toml
-[model_providers.openai]
-name = "OpenAI"
-base_url = "https://api.openai.com/v1"
-env_key = "OPENAI_API_KEY"
-wire_api = "responses"
-```
-
 ## model_providers
 
-This option lets you override and amend the default set of model providers bundled with Codex. This value is a map where the key is the value to use with `model_provider` to select the correspodning provider.
+This option lets you override and amend the default set of model providers bundled with Codex. This value is a map where the key is the value to use with `model_provider` to select the corresponding provider.
 
-For example, if you wanted to add a provider that uses the OpenAI 4o model via the chat completions API, then you
+For example, if you wanted to add a provider that uses the OpenAI 4o model via the chat completions API, then you could add the following configuration:
 
 ```toml
 # Recall that in TOML, root keys must be listed before tables.
@@ -71,8 +41,40 @@ base_url = "https://api.openai.com/v1"
 # using Codex with this provider. The value of the environment variable must be
 # non-empty and will be used in the `Bearer TOKEN` HTTP header for the POST request.
 env_key = "OPENAI_API_KEY"
-# valid values for wire_api are "chat" and "responses".
+# Valid values for wire_api are "chat" and "responses".
 wire_api = "chat"
+```
+
+Note this makes it possible to use Codex CLI with non-OpenAI models, so long as they use a wire API that is compatible with the OpenAI chat completions API. For example, you could define the following provider to use Codex CLI with Ollama running locally:
+
+```toml
+[model_providers.ollama]
+name = "Ollama"
+base_url = "http://localhost:11434/v1"
+wire_api = "chat"
+```
+
+Or a third-party provider (using a distinct environment variable for the API key):
+
+```toml
+[model_providers.mistral]
+name = "Mistral"
+base_url = "https://api.mistral.ai/v1"
+env_key = "MISTRAL_API_KEY"
+wire_api = "chat"
+```
+
+## model_provider
+
+Identifies which provider to use from the `model_providers` map. Defaults to `"openai"`.
+
+Note that if you override `model_provider`, then you likely want to override
+`model`, as well. For example, if you are running ollama with Mistral locally,
+then you would need to add the following to your config in addition to the new entry in the `model_providers` map:
+
+```toml
+model = "mistral"
+model_provider = "ollama"
 ```
 
 ## approval_policy

--- a/codex-rs/config.md
+++ b/codex-rs/config.md
@@ -407,6 +407,16 @@ Setting `hide_agent_reasoning` to `true` suppresses these events in **both** the
 hide_agent_reasoning = true   # defaults to false
 ```
 
+## model_context_window
+
+The size of the context window for the model, in tokens.
+
+In general, Codex knows the context window for the most common OpenAI models, but if you are using a new model with an old version of the Codex CLI, then you can use `model_context_window` to tell Codex what value to use to determine how much context is left during a conversation.
+
+## model_max_output_tokens
+
+This is analogous to `model_context_window`, but for the maximum number of output tokens for the model.
+
 ## project_doc_max_bytes
 
 Maximum number of bytes to read from an `AGENTS.md` file to include in the instructions sent with the first turn of a session. Defaults to 32 KiB.

--- a/codex-rs/config.md
+++ b/codex-rs/config.md
@@ -80,8 +80,13 @@ wire_api = "chat"
 Determines when the user should be prompted to approve whether Codex can execute a command:
 
 ```toml
-# This is analogous to --suggest in the TypeScript Codex CLI
-approval_policy = "unless-allow-listed"
+# Codex has hardcoded logic that defines a set of "trusted" commands.
+# Setting the approval_policy to `untrusted` means that Codex will prompt the
+# user before running a command not in the "trusted" set.
+#
+# See https://github.com/openai/codex/issues/1260 for the plan to enable
+# end-users to define their own trusted commands.
+approval_policy = "untrusted"
 ```
 
 ```toml

--- a/codex-rs/core/src/chat_completions.rs
+++ b/codex-rs/core/src/chat_completions.rs
@@ -215,6 +215,7 @@ where
                 let _ = tx_event
                     .send(Ok(ResponseEvent::Completed {
                         response_id: String::new(),
+                        token_usage: None,
                     }))
                     .await;
                 return;
@@ -232,6 +233,7 @@ where
             let _ = tx_event
                 .send(Ok(ResponseEvent::Completed {
                     response_id: String::new(),
+                    token_usage: None,
                 }))
                 .await;
             return;
@@ -317,6 +319,7 @@ where
                 let _ = tx_event
                     .send(Ok(ResponseEvent::Completed {
                         response_id: String::new(),
+                        token_usage: None,
                     }))
                     .await;
 
@@ -394,7 +397,10 @@ where
                     // Not an assistant message – forward immediately.
                     return Poll::Ready(Some(Ok(ResponseEvent::OutputItemDone(item))));
                 }
-                Poll::Ready(Some(Ok(ResponseEvent::Completed { response_id }))) => {
+                Poll::Ready(Some(Ok(ResponseEvent::Completed {
+                    response_id,
+                    token_usage,
+                }))) => {
                     if !this.cumulative.is_empty() {
                         let aggregated_item = crate::models::ResponseItem::Message {
                             role: "assistant".to_string(),
@@ -404,7 +410,10 @@ where
                         };
 
                         // Buffer Completed so it is returned *after* the aggregated message.
-                        this.pending_completed = Some(ResponseEvent::Completed { response_id });
+                        this.pending_completed = Some(ResponseEvent::Completed {
+                            response_id,
+                            token_usage,
+                        });
 
                         return Poll::Ready(Some(Ok(ResponseEvent::OutputItemDone(
                             aggregated_item,
@@ -412,7 +421,10 @@ where
                     }
 
                     // Nothing aggregated – forward Completed directly.
-                    return Poll::Ready(Some(Ok(ResponseEvent::Completed { response_id })));
+                    return Poll::Ready(Some(Ok(ResponseEvent::Completed {
+                        response_id,
+                        token_usage,
+                    })));
                 } // No other `Ok` variants exist at the moment, continue polling.
             }
         }

--- a/codex-rs/core/src/chat_completions.rs
+++ b/codex-rs/core/src/chat_completions.rs
@@ -114,8 +114,7 @@ pub(crate) async fn stream_chat_completions(
         "tools": tools_json,
     });
 
-    let base_url = provider.base_url.trim_end_matches('/');
-    let url = format!("{}/chat/completions", base_url);
+    let url = provider.get_full_url();
 
     debug!(
         "POST to {url}: {}",

--- a/codex-rs/core/src/chat_completions.rs
+++ b/codex-rs/core/src/chat_completions.rs
@@ -425,7 +425,12 @@ where
                         response_id,
                         token_usage,
                     })));
-                } // No other `Ok` variants exist at the moment, continue polling.
+                }
+                Poll::Ready(Some(Ok(ResponseEvent::Created))) => {
+                    // These events are exclusive to the Responses API and
+                    // will never appear in a Chat Completions stream.
+                    continue;
+                }
             }
         }
     }
@@ -439,7 +444,7 @@ pub(crate) trait AggregateStreamExt: Stream<Item = Result<ResponseEvent>> + Size
     ///
     /// ```ignore
     ///     OutputItemDone(<full message>)
-    ///     Completed { .. }
+    ///     Completed
     /// ```
     ///
     /// No other `OutputItemDone` events will be seen by the caller.

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -123,9 +123,7 @@ impl ModelClient {
             stream: true,
         };
 
-        let base_url = self.provider.base_url.clone();
-        let base_url = base_url.trim_end_matches('/');
-        let url = format!("{}/responses", base_url);
+        let url = self.provider.get_full_url();
         trace!("POST to {url}: {}", serde_json::to_string(&payload)?);
 
         let mut attempt = 0;

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -168,7 +168,7 @@ impl ModelClient {
                     // negligible.
                     if !(status == StatusCode::TOO_MANY_REQUESTS || status.is_server_error()) {
                         // Surface the error body to callers. Use `unwrap_or_default` per Clippy.
-                        let body = (res.text().await).unwrap_or_default();
+                        let body = res.text().await.unwrap_or_default();
                         return Err(CodexErr::UnexpectedStatus(status, body));
                     }
 
@@ -207,6 +207,9 @@ struct SseEvent {
     response: Option<Value>,
     item: Option<Value>,
 }
+
+#[derive(Debug, Deserialize)]
+struct ResponseCreated {}
 
 #[derive(Debug, Deserialize)]
 struct ResponseCompleted {
@@ -335,6 +338,11 @@ where
                     return;
                 }
             }
+            "response.created" => {
+                if event.response.is_some() {
+                    let _ = tx_event.send(Ok(ResponseEvent::Created {})).await;
+                }
+            }
             // Final response completed – includes array of output items & id
             "response.completed" => {
                 if let Some(resp_val) = event.response {
@@ -350,7 +358,6 @@ where
                 };
             }
             "response.content_part.done"
-            | "response.created"
             | "response.function_call_arguments.delta"
             | "response.in_progress"
             | "response.output_item.added"

--- a/codex-rs/core/src/client_common.rs
+++ b/codex-rs/core/src/client_common.rs
@@ -2,6 +2,7 @@ use crate::config_types::ReasoningEffort as ReasoningEffortConfig;
 use crate::config_types::ReasoningSummary as ReasoningSummaryConfig;
 use crate::error::Result;
 use crate::models::ResponseItem;
+use crate::protocol::TokenUsage;
 use codex_apply_patch::APPLY_PATCH_TOOL_INSTRUCTIONS;
 use futures::Stream;
 use serde::Serialize;
@@ -51,7 +52,10 @@ impl Prompt {
 #[derive(Debug)]
 pub enum ResponseEvent {
     OutputItemDone(ResponseItem),
-    Completed { response_id: String },
+    Completed {
+        response_id: String,
+        token_usage: Option<TokenUsage>,
+    },
 }
 
 #[derive(Debug, Serialize)]

--- a/codex-rs/core/src/client_common.rs
+++ b/codex-rs/core/src/client_common.rs
@@ -51,6 +51,7 @@ impl Prompt {
 
 #[derive(Debug)]
 pub enum ResponseEvent {
+    Created,
     OutputItemDone(ResponseItem),
     Completed {
         response_id: String,

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1078,7 +1078,20 @@ async fn try_run_turn(
                 let response = handle_response_item(sess, sub_id, item.clone()).await?;
                 output.push(ProcessedResponseItem { item, response });
             }
-            ResponseEvent::Completed { response_id } => {
+            ResponseEvent::Completed {
+                response_id,
+                token_usage,
+            } => {
+                if let Some(token_usage) = token_usage {
+                    sess.tx_event
+                        .send(Event {
+                            id: sub_id.to_string(),
+                            msg: EventMsg::TokenCount(token_usage),
+                        })
+                        .await
+                        .ok();
+                }
+
                 let mut state = sess.state.lock().unwrap();
                 state.previous_response_id = Some(response_id);
                 break;

--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -658,6 +658,7 @@ disable_response_storage = true
             env_key: Some("OPENAI_API_KEY".to_string()),
             wire_api: crate::WireApi::Chat,
             env_key_instructions: None,
+            query_params: None,
         };
         let model_provider_map = {
             let mut model_provider_map = built_in_model_providers();

--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -586,7 +586,7 @@ writable_roots = [
     fn create_test_fixture() -> std::io::Result<PrecedenceTestFixture> {
         let toml = r#"
 model = "o3"
-approval_policy = "unless-allow-listed"
+approval_policy = "untrusted"
 disable_response_storage = false
 
 # Can be used to determine which profile to use if not specified by

--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -731,7 +731,7 @@ disable_response_storage = true
             model: "gpt-3.5-turbo".to_string(),
             model_provider_id: "openai-chat-completions".to_string(),
             model_provider: fixture.openai_chat_completions_provider.clone(),
-            approval_policy: AskForApproval::UnlessAllowListed,
+            approval_policy: AskForApproval::UnlessTrusted,
             sandbox_policy: SandboxPolicy::new_read_only_policy(),
             shell_environment_policy: ShellEnvironmentPolicy::default(),
             disable_response_storage: false,

--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -28,6 +28,7 @@ pub use model_provider_info::ModelProviderInfo;
 pub use model_provider_info::WireApi;
 mod models;
 pub mod openai_api_key;
+mod openai_model_info;
 mod openai_tools;
 mod project_doc;
 pub mod protocol;

--- a/codex-rs/core/src/model_provider_info.rs
+++ b/codex-rs/core/src/model_provider_info.rs
@@ -83,6 +83,10 @@ impl ModelProviderInfo {
 pub fn built_in_model_providers() -> HashMap<String, ModelProviderInfo> {
     use ModelProviderInfo as P;
 
+    // We do not want to be in the business of adjucating which third-party
+    // providers are bundled with Codex CLI, so we only include the OpenAI
+    // provider by default. Users are encouraged to add to `model_providers`
+    // in config.toml to add their own providers.
     [
         (
             "openai",
@@ -92,76 +96,6 @@ pub fn built_in_model_providers() -> HashMap<String, ModelProviderInfo> {
                 env_key: Some("OPENAI_API_KEY".into()),
                 env_key_instructions: Some("Create an API key (https://platform.openai.com) and export it as an environment variable.".into()),
                 wire_api: WireApi::Responses,
-            },
-        ),
-        (
-            "openrouter",
-            P {
-                name: "OpenRouter".into(),
-                base_url: "https://openrouter.ai/api/v1".into(),
-                env_key: Some("OPENROUTER_API_KEY".into()),
-                env_key_instructions: None,
-                wire_api: WireApi::Chat,
-            },
-        ),
-        (
-            "gemini",
-            P {
-                name: "Gemini".into(),
-                base_url: "https://generativelanguage.googleapis.com/v1beta/openai".into(),
-                env_key: Some("GEMINI_API_KEY".into()),
-                env_key_instructions: None,
-                wire_api: WireApi::Chat,
-            },
-        ),
-        (
-            "ollama",
-            P {
-                name: "Ollama".into(),
-                base_url: "http://localhost:11434/v1".into(),
-                env_key: None,
-                env_key_instructions: None,
-                wire_api: WireApi::Chat,
-            },
-        ),
-        (
-            "mistral",
-            P {
-                name: "Mistral".into(),
-                base_url: "https://api.mistral.ai/v1".into(),
-                env_key: Some("MISTRAL_API_KEY".into()),
-                env_key_instructions: None,
-                wire_api: WireApi::Chat,
-            },
-        ),
-        (
-            "deepseek",
-            P {
-                name: "DeepSeek".into(),
-                base_url: "https://api.deepseek.com".into(),
-                env_key: Some("DEEPSEEK_API_KEY".into()),
-                env_key_instructions: None,
-                wire_api: WireApi::Chat,
-            },
-        ),
-        (
-            "xai",
-            P {
-                name: "xAI".into(),
-                base_url: "https://api.x.ai/v1".into(),
-                env_key: Some("XAI_API_KEY".into()),
-                env_key_instructions: None,
-                wire_api: WireApi::Chat,
-            },
-        ),
-        (
-            "groq",
-            P {
-                name: "Groq".into(),
-                base_url: "https://api.groq.com/openai/v1".into(),
-                env_key: Some("GROQ_API_KEY".into()),
-                env_key_instructions: None,
-                wire_api: WireApi::Chat,
             },
         ),
     ]

--- a/codex-rs/core/src/openai_model_info.rs
+++ b/codex-rs/core/src/openai_model_info.rs
@@ -1,0 +1,71 @@
+/// Metadata about a model, particularly OpenAI models.
+/// We may want to consider including details like the pricing for
+/// input tokens, output tokens, etc., though users will need to be able to
+/// override this in config.toml, as this information can get out of date.
+/// Though this would help present more accurate pricing information in the UI.
+#[derive(Debug)]
+pub(crate) struct ModelInfo {
+    /// Size of the context window in tokens.
+    pub(crate) context_window: u64,
+
+    /// Maximum number of output tokens that can be generated for the model.
+    pub(crate) max_output_tokens: u64,
+}
+
+/// Note details such as what a model like gpt-4o is aliased to may be out of
+/// date.
+pub(crate) fn get_model_info(name: &str) -> Option<ModelInfo> {
+    match name {
+        // https://platform.openai.com/docs/models/o3
+        "o3" => Some(ModelInfo {
+            context_window: 200_000,
+            max_output_tokens: 100_000,
+        }),
+
+        // https://platform.openai.com/docs/models/o4-mini
+        "o4-mini" => Some(ModelInfo {
+            context_window: 200_000,
+            max_output_tokens: 100_000,
+        }),
+
+        // https://platform.openai.com/docs/models/codex-mini-latest
+        "codex-mini-latest" => Some(ModelInfo {
+            context_window: 200_000,
+            max_output_tokens: 100_000,
+        }),
+
+        // As of Jun 25, 2025, gpt-4.1 defaults to gpt-4.1-2025-04-14.
+        // https://platform.openai.com/docs/models/gpt-4.1
+        "gpt-4.1" | "gpt-4.1-2025-04-14" => Some(ModelInfo {
+            context_window: 1_047_576,
+            max_output_tokens: 32_768,
+        }),
+
+        // As of Jun 25, 2025, gpt-4o defaults to gpt-4o-2024-08-06.
+        // https://platform.openai.com/docs/models/gpt-4o
+        "gpt-4o" | "gpt-4o-2024-08-06" => Some(ModelInfo {
+            context_window: 128_000,
+            max_output_tokens: 16_384,
+        }),
+
+        // https://platform.openai.com/docs/models/gpt-4o?snapshot=gpt-4o-2024-05-13
+        "gpt-4o-2024-05-13" => Some(ModelInfo {
+            context_window: 128_000,
+            max_output_tokens: 4_096,
+        }),
+
+        // https://platform.openai.com/docs/models/gpt-4o?snapshot=gpt-4o-2024-11-20
+        "gpt-4o-2024-11-20" => Some(ModelInfo {
+            context_window: 128_000,
+            max_output_tokens: 16_384,
+        }),
+
+        // https://platform.openai.com/docs/models/gpt-3.5-turbo
+        "gpt-3.5-turbo" => Some(ModelInfo {
+            context_window: 16_385,
+            max_output_tokens: 4_096,
+        }),
+
+        _ => None,
+    }
+}

--- a/codex-rs/core/src/protocol.rs
+++ b/codex-rs/core/src/protocol.rs
@@ -120,7 +120,7 @@ pub enum AskForApproval {
     /// Everything else will ask the user to approve.
     #[default]
     #[serde(rename = "untrusted")]
-    UnlessAllowListed,
+    UnlessTrusted,
 
     /// *All* commands are auto‑approved, but they are expected to run inside a
     /// sandbox where network access is disabled and writes are confined to a

--- a/codex-rs/core/src/protocol.rs
+++ b/codex-rs/core/src/protocol.rs
@@ -231,12 +231,6 @@ impl SandboxPolicy {
             }
         }
     }
-
-    // TODO(mbolin): This conflates sandbox policy and approval policy and
-    // should go away.
-    pub fn is_unrestricted(&self) -> bool {
-        matches!(self, SandboxPolicy::DangerFullAccess)
-    }
 }
 
 /// User input

--- a/codex-rs/core/src/protocol.rs
+++ b/codex-rs/core/src/protocol.rs
@@ -275,6 +275,10 @@ pub enum EventMsg {
     /// Agent has completed all actions
     TaskComplete(TaskCompleteEvent),
 
+    /// Token count event, sent periodically to report the number of tokens
+    /// used in the current session.
+    TokenCount(TokenUsage),
+
     /// Agent text output message
     AgentMessage(AgentMessageEvent),
 
@@ -320,6 +324,15 @@ pub struct ErrorEvent {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct TaskCompleteEvent {
     pub last_agent_message: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+pub struct TokenUsage {
+    pub input_tokens: u64,
+    pub cached_input_tokens: Option<u64>,
+    pub output_tokens: u64,
+    pub reasoning_output_tokens: Option<u64>,
+    pub total_tokens: u64,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/codex-rs/core/src/protocol.rs
+++ b/codex-rs/core/src/protocol.rs
@@ -110,21 +110,17 @@ pub enum Op {
     GetHistoryEntryRequest { offset: usize, log_id: u64 },
 }
 
-/// Determines how liberally commands are auto‑approved by the system.
+/// Determines the conditions under which the user is consulted to approve
+/// running the command proposed by Codex.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum AskForApproval {
-    /// Under this policy, only “known safe” commands—as determined by
+    /// Under this policy, only "known safe" commands—as determined by
     /// `is_safe_command()`—that **only read files** are auto‑approved.
     /// Everything else will ask the user to approve.
     #[default]
+    #[serde(rename = "untrusted")]
     UnlessAllowListed,
-
-    /// In addition to everything allowed by **`Suggest`**, commands that
-    /// *write* to files **within the user’s approved list of writable paths**
-    /// are also auto‑approved.
-    /// TODO(ragona): fix
-    AutoEdit,
 
     /// *All* commands are auto‑approved, but they are expected to run inside a
     /// sandbox where network access is disabled and writes are confined to a

--- a/codex-rs/core/src/safety.rs
+++ b/codex-rs/core/src/safety.rs
@@ -36,7 +36,7 @@ pub fn assess_patch_safety(
         }
         // TODO(ragona): I'm not sure this is actually correct? I believe in this case
         // we want to continue to the writable paths check before asking the user.
-        AskForApproval::UnlessAllowListed => {
+        AskForApproval::UnlessTrusted => {
             return SafetyCheck::AskUser;
         }
     }

--- a/codex-rs/core/src/safety.rs
+++ b/codex-rs/core/src/safety.rs
@@ -31,7 +31,7 @@ pub fn assess_patch_safety(
     }
 
     match policy {
-        AskForApproval::OnFailure | AskForApproval::AutoEdit | AskForApproval::Never => {
+        AskForApproval::OnFailure | AskForApproval::Never => {
             // Continue to see if this can be auto-approved.
         }
         // TODO(ragona): I'm not sure this is actually correct? I believe in this case

--- a/codex-rs/core/src/safety.rs
+++ b/codex-rs/core/src/safety.rs
@@ -63,40 +63,71 @@ pub fn assess_patch_safety(
     }
 }
 
+/// For a command to be run _without_ a sandbox, one of the following must be
+/// true:
+///
+/// - the user has explicitly approved the command
+/// - the command is on the "known safe" list
+/// - `DangerFullAccess` was specified and `UnlessTrusted` was not
 pub fn assess_command_safety(
     command: &[String],
     approval_policy: AskForApproval,
     sandbox_policy: &SandboxPolicy,
     approved: &HashSet<Vec<String>>,
 ) -> SafetyCheck {
-    let approve_without_sandbox = || SafetyCheck::AutoApprove {
-        sandbox_type: SandboxType::None,
-    };
+    use AskForApproval::*;
+    use SandboxPolicy::*;
 
-    // Previously approved or allow-listed commands
-    // All approval modes allow these commands to continue without sandboxing
+    // A command is "trusted" because either:
+    // - it belongs to a set of commands we consider "safe" by default, or
+    // - the user has explicitly approved the command for this session
+    //
+    // Currently, whether a command is "trusted" is a simple boolean, but we
+    // should include more metadata on this command test to indicate whether it
+    // should be run inside a sandbox or not. (This could be something the user
+    // defines as part of `execpolicy`.)
+    //
+    // For example, when `is_known_safe_command(command)` returns `true`, it
+    // would probably be fine to run the command in a sandbox, but when
+    // `approved.contains(command)` is `true`, the user may have approved it for
+    // the session _because_ they know it needs to run outside a sandbox.
     if is_known_safe_command(command) || approved.contains(command) {
-        // TODO(ragona): I think we should consider running even these inside the sandbox, but it's
-        // a change in behavior so I'm keeping it at parity with upstream for now.
-        return approve_without_sandbox();
+        return SafetyCheck::AutoApprove {
+            sandbox_type: SandboxType::None,
+        };
     }
 
-    // Command was not known-safe or allow-listed
-    if sandbox_policy.is_unrestricted() {
-        approve_without_sandbox()
-    } else {
-        match get_platform_sandbox() {
-            // We have a sandbox, so we can approve the command in all modes
-            Some(sandbox_type) => SafetyCheck::AutoApprove { sandbox_type },
-            None => {
-                // We do not have a sandbox, so we need to consider the approval policy
-                match approval_policy {
-                    // Never is our "non-interactive" mode; it must automatically reject
-                    AskForApproval::Never => SafetyCheck::Reject {
-                        reason: "auto-rejected by user approval settings".to_string(),
-                    },
-                    // Otherwise, we ask the user for approval
-                    _ => SafetyCheck::AskUser,
+    match (approval_policy, sandbox_policy) {
+        (UnlessTrusted, _) => {
+            // Even though the user may have opted into DangerFullAccess,
+            // they also requested that we ask for approval for untrusted
+            // commands.
+            SafetyCheck::AskUser
+        }
+        (OnFailure, DangerFullAccess) | (Never, DangerFullAccess) => SafetyCheck::AutoApprove {
+            sandbox_type: SandboxType::None,
+        },
+        (Never, ReadOnly)
+        | (Never, WorkspaceWrite { .. })
+        | (OnFailure, ReadOnly)
+        | (OnFailure, WorkspaceWrite { .. }) => {
+            match get_platform_sandbox() {
+                Some(sandbox_type) => SafetyCheck::AutoApprove { sandbox_type },
+                None => {
+                    if matches!(approval_policy, OnFailure) {
+                        // Since the command is not trusted, even though the
+                        // user has requested to only ask for approval on
+                        // failure, we will ask the user because no sandbox is
+                        // available.
+                        SafetyCheck::AskUser
+                    } else {
+                        // We are in non-interactive mode and lack approval, so
+                        // all we can do is reject the command.
+                        SafetyCheck::Reject {
+                            reason: "auto-rejected because command is not on trusted list"
+                                .to_string(),
+                        }
+                    }
                 }
             }
         }

--- a/codex-rs/core/tests/previous_response_id.rs
+++ b/codex-rs/core/tests/previous_response_id.rs
@@ -107,6 +107,7 @@ async fn keeps_previous_response_id_between_tasks() {
         env_key: Some("PATH".into()),
         env_key_instructions: None,
         wire_api: codex_core::WireApi::Responses,
+        query_params: None,
     };
 
     // Init session

--- a/codex-rs/core/tests/stream_no_completed.rs
+++ b/codex-rs/core/tests/stream_no_completed.rs
@@ -96,6 +96,7 @@ async fn retries_on_early_close() {
         env_key: Some("PATH".into()),
         env_key_instructions: None,
         wire_api: codex_core::WireApi::Responses,
+        query_params: None,
     };
 
     let ctrl_c = std::sync::Arc::new(tokio::sync::Notify::new());

--- a/codex-rs/exec/Cargo.toml
+++ b/codex-rs/exec/Cargo.toml
@@ -19,7 +19,11 @@ anyhow = "1"
 chrono = "0.4.40"
 clap = { version = "4", features = ["derive"] }
 codex-core = { path = "../core" }
-codex-common = { path = "../common", features = ["cli", "elapsed"] }
+codex-common = { path = "../common", features = [
+    "cli",
+    "elapsed",
+    "sandbox_summary",
+] }
 codex-linux-sandbox = { path = "../linux-sandbox" }
 mcp-types = { path = "../mcp-types" }
 owo-colors = "4.2.0"

--- a/codex-rs/exec/src/cli.rs
+++ b/codex-rs/exec/src/cli.rs
@@ -1,7 +1,6 @@
 use clap::Parser;
 use clap::ValueEnum;
 use codex_common::CliConfigOverrides;
-use codex_common::SandboxPermissionOption;
 use std::path::PathBuf;
 
 #[derive(Parser, Debug)]
@@ -22,9 +21,6 @@ pub struct Cli {
     /// Convenience alias for low-friction sandboxed automatic execution (network-disabled sandbox that can write to cwd and TMPDIR)
     #[arg(long = "full-auto", default_value_t = false)]
     pub full_auto: bool,
-
-    #[clap(flatten)]
-    pub sandbox: SandboxPermissionOption,
 
     /// Tell the agent to use the specified directory as its working root.
     #[clap(long = "cd", short = 'C', value_name = "DIR")]

--- a/codex-rs/exec/src/cli.rs
+++ b/codex-rs/exec/src/cli.rs
@@ -18,7 +18,7 @@ pub struct Cli {
     #[arg(long = "profile", short = 'p')]
     pub config_profile: Option<String>,
 
-    /// Convenience alias for low-friction sandboxed automatic execution (network-disabled sandbox that can write to cwd and TMPDIR)
+    /// Convenience alias for low-friction sandboxed automatic execution (-a on-failure, -c sandbox.mode=workspace-write).
     #[arg(long = "full-auto", default_value_t = false)]
     pub full_auto: bool,
 

--- a/codex-rs/exec/src/cli.rs
+++ b/codex-rs/exec/src/cli.rs
@@ -22,6 +22,15 @@ pub struct Cli {
     #[arg(long = "full-auto", default_value_t = false)]
     pub full_auto: bool,
 
+    /// Skip all confirmation prompts and execute commands without sandboxing.
+    /// EXTREMELY DANGEROUS. Intended solely for running in environments that are externally sandboxed.
+    #[arg(
+        long = "dangerously-bypass-approvals-and-sandbox",
+        default_value_t = false,
+        conflicts_with = "full_auto"
+    )]
+    pub dangerously_bypass_approvals_and_sandbox: bool,
+
     /// Tell the agent to use the specified directory as its working root.
     #[clap(long = "cd", short = 'C', value_name = "DIR")]
     pub cwd: Option<PathBuf>,

--- a/codex-rs/exec/src/event_processor.rs
+++ b/codex-rs/exec/src/event_processor.rs
@@ -16,6 +16,7 @@ use codex_core::protocol::McpToolCallEndEvent;
 use codex_core::protocol::PatchApplyBeginEvent;
 use codex_core::protocol::PatchApplyEndEvent;
 use codex_core::protocol::SessionConfiguredEvent;
+use codex_core::protocol::TokenUsage;
 use owo_colors::OwoColorize;
 use owo_colors::Style;
 use shlex::try_join;
@@ -179,6 +180,9 @@ impl EventProcessor {
             }
             EventMsg::TaskStarted | EventMsg::TaskComplete(_) => {
                 // Ignore.
+            }
+            EventMsg::TokenCount(TokenUsage { total_tokens, .. }) => {
+                ts_println!(self, "tokens used: {total_tokens}");
             }
             EventMsg::AgentMessage(AgentMessageEvent { message }) => {
                 ts_println!(

--- a/codex-rs/exec/src/event_processor.rs
+++ b/codex-rs/exec/src/event_processor.rs
@@ -1,4 +1,5 @@
 use codex_common::elapsed::format_elapsed;
+use codex_common::summarize_sandbox_policy;
 use codex_core::WireApi;
 use codex_core::config::Config;
 use codex_core::model_supports_reasoning_summaries;
@@ -134,7 +135,7 @@ impl EventProcessor {
             ("model", config.model.clone()),
             ("provider", config.model_provider_id.clone()),
             ("approval", format!("{:?}", config.approval_policy)),
-            ("sandbox", format!("{:?}", config.sandbox_policy)),
+            ("sandbox", summarize_sandbox_policy(&config.sandbox_policy)),
         ];
         if config.model_provider.wire_api == WireApi::Responses
             && model_supports_reasoning_summaries(&config.model)

--- a/codex-rs/exec/src/lib.rs
+++ b/codex-rs/exec/src/lib.rs
@@ -31,7 +31,6 @@ pub async fn run_main(cli: Cli, codex_linux_sandbox_exe: Option<PathBuf>) -> any
         model,
         config_profile,
         full_auto,
-        sandbox,
         cwd,
         skip_git_repo_check,
         color,
@@ -85,9 +84,9 @@ pub async fn run_main(cli: Cli, codex_linux_sandbox_exe: Option<PathBuf>) -> any
     };
 
     let sandbox_policy = if full_auto {
-        Some(SandboxPolicy::new_full_auto_policy())
+        Some(SandboxPolicy::new_workspace_write_policy())
     } else {
-        sandbox.permissions.clone().map(Into::into)
+        None
     };
 
     // Load configuration and determine approval policy

--- a/codex-rs/exec/src/lib.rs
+++ b/codex-rs/exec/src/lib.rs
@@ -31,6 +31,7 @@ pub async fn run_main(cli: Cli, codex_linux_sandbox_exe: Option<PathBuf>) -> any
         model,
         config_profile,
         full_auto,
+        dangerously_bypass_approvals_and_sandbox,
         cwd,
         skip_git_repo_check,
         color,
@@ -85,6 +86,8 @@ pub async fn run_main(cli: Cli, codex_linux_sandbox_exe: Option<PathBuf>) -> any
 
     let sandbox_policy = if full_auto {
         Some(SandboxPolicy::new_workspace_write_policy())
+    } else if dangerously_bypass_approvals_and_sandbox {
+        Some(SandboxPolicy::DangerFullAccess)
     } else {
         None
     };

--- a/codex-rs/file-search/Cargo.toml
+++ b/codex-rs/file-search/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "codex-file-search"
+version = { workspace = true }
+edition = "2024"
+
+[[bin]]
+name = "codex-file-search"
+path = "src/main.rs"
+
+[lib]
+name = "codex_file_search"
+path = "src/lib.rs"
+
+[dependencies]
+anyhow = "1"
+clap = { version = "4", features = ["derive"] }
+ignore = "0.4.23"
+nucleo-matcher = "0.3.1"
+serde_json = "1.0.110"
+tokio = { version = "1", features = ["full"] }

--- a/codex-rs/file-search/Cargo.toml
+++ b/codex-rs/file-search/Cargo.toml
@@ -16,5 +16,6 @@ anyhow = "1"
 clap = { version = "4", features = ["derive"] }
 ignore = "0.4.23"
 nucleo-matcher = "0.3.1"
+serde = { version = "1", features = ["derive"] }
 serde_json = "1.0.110"
 tokio = { version = "1", features = ["full"] }

--- a/codex-rs/file-search/README.md
+++ b/codex-rs/file-search/README.md
@@ -1,0 +1,5 @@
+# codex_file_search
+
+Fast fuzzy file search tool for Codex.
+
+Uses <https://crates.io/crates/ignore> under the hood (which is what `ripgrep` uses) to traverse a directory (while honoring `.gitignore`, etc.) to produce the list of files to search and then uses <https://crates.io/crates/nucleo-matcher> to fuzzy-match the user supplied `PATTERN` against the corpus.

--- a/codex-rs/file-search/src/cli.rs
+++ b/codex-rs/file-search/src/cli.rs
@@ -1,0 +1,38 @@
+use std::num::NonZero;
+use std::path::PathBuf;
+
+use clap::ArgAction;
+use clap::Parser;
+
+/// Fuzzy matches filenames under a directory.
+#[derive(Parser)]
+#[command(version)]
+pub struct Cli {
+    /// Whether to output results in JSON format.
+    #[clap(long, default_value = "false")]
+    pub json: bool,
+
+    /// Maximum number of results to return.
+    #[clap(long, short = 'l', default_value = "64")]
+    pub limit: NonZero<usize>,
+
+    /// Directory to search.
+    #[clap(long, short = 'C')]
+    pub cwd: Option<PathBuf>,
+
+    // While it is common to default to the number of logical CPUs when creating
+    // a thread pool, empirically, the I/O of the filetree traversal offers
+    // limited parallelism and is the bottleneck, so using a smaller number of
+    // threads is more efficient. (Empirically, using more than 2 threads doesn't seem to provide much benefit.)
+    //
+    /// Number of worker threads to use.
+    #[clap(long, default_value = "2")]
+    pub threads: NonZero<usize>,
+
+    /// Exclude patterns
+    #[arg(short, long, action = ArgAction::Append)]
+    pub exclude: Vec<String>,
+
+    /// Search pattern.
+    pub pattern: Option<String>,
+}

--- a/codex-rs/file-search/src/cli.rs
+++ b/codex-rs/file-search/src/cli.rs
@@ -20,6 +20,10 @@ pub struct Cli {
     #[clap(long, short = 'C')]
     pub cwd: Option<PathBuf>,
 
+    /// Include matching file indices in the output.
+    #[arg(long, default_value = "false")]
+    pub compute_indices: bool,
+
     // While it is common to default to the number of logical CPUs when creating
     // a thread pool, empirically, the I/O of the filetree traversal offers
     // limited parallelism and is the bottleneck, so using a smaller number of

--- a/codex-rs/file-search/src/lib.rs
+++ b/codex-rs/file-search/src/lib.rs
@@ -1,0 +1,284 @@
+use ignore::WalkBuilder;
+use ignore::overrides::OverrideBuilder;
+use nucleo_matcher::Matcher;
+use nucleo_matcher::Utf32Str;
+use nucleo_matcher::pattern::AtomKind;
+use nucleo_matcher::pattern::CaseMatching;
+use nucleo_matcher::pattern::Normalization;
+use nucleo_matcher::pattern::Pattern;
+use std::cell::UnsafeCell;
+use std::cmp::Reverse;
+use std::collections::BinaryHeap;
+use std::num::NonZero;
+use std::path::Path;
+use std::path::PathBuf;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use tokio::process::Command;
+
+mod cli;
+
+pub use cli::Cli;
+
+pub struct FileSearchResults {
+    pub matches: Vec<(u32, String)>,
+    pub total_match_count: usize,
+}
+
+pub trait Reporter {
+    fn report_match(&self, file: &str, score: u32);
+    fn warn_matches_truncated(&self, total_match_count: usize, shown_match_count: usize);
+    fn warn_no_search_pattern(&self, search_directory: &Path);
+}
+
+pub async fn run_main<T: Reporter>(
+    Cli {
+        pattern,
+        limit,
+        cwd,
+        json: _,
+        exclude,
+        threads,
+    }: Cli,
+    reporter: T,
+) -> anyhow::Result<()> {
+    let search_directory = match cwd {
+        Some(dir) => dir,
+        None => std::env::current_dir()?,
+    };
+    let pattern_text = match pattern {
+        Some(pattern) => pattern,
+        None => {
+            reporter.warn_no_search_pattern(&search_directory);
+            #[cfg(unix)]
+            Command::new("ls")
+                .arg("-al")
+                .current_dir(search_directory)
+                .stdout(std::process::Stdio::inherit())
+                .stderr(std::process::Stdio::inherit())
+                .status()
+                .await?;
+            #[cfg(windows)]
+            {
+                Command::new("cmd")
+                    .arg("/c")
+                    .arg(search_directory)
+                    .stdout(std::process::Stdio::inherit())
+                    .stderr(std::process::Stdio::inherit())
+                    .status()
+                    .await?;
+            }
+            return Ok(());
+        }
+    };
+
+    let FileSearchResults {
+        total_match_count,
+        matches,
+    } = run(&pattern_text, limit, search_directory, exclude, threads).await?;
+    let match_count = matches.len();
+    let matches_truncated = total_match_count > match_count;
+
+    for (score, file) in matches {
+        reporter.report_match(&file, score);
+    }
+    if matches_truncated {
+        reporter.warn_matches_truncated(total_match_count, match_count);
+    }
+
+    Ok(())
+}
+
+pub async fn run(
+    pattern_text: &str,
+    limit: NonZero<usize>,
+    search_directory: PathBuf,
+    exclude: Vec<String>,
+    threads: NonZero<usize>,
+) -> anyhow::Result<FileSearchResults> {
+    let pattern = create_pattern(pattern_text);
+    // Create one BestMatchesList per worker thread so that each worker can
+    // operate independently. The results across threads will be merged when
+    // the traversal is complete.
+    let WorkerCount {
+        num_walk_builder_threads,
+        num_best_matches_lists,
+    } = create_worker_count(threads);
+    let best_matchers_per_worker: Vec<UnsafeCell<BestMatchesList>> = (0..num_best_matches_lists)
+        .map(|_| {
+            UnsafeCell::new(BestMatchesList::new(
+                limit.get(),
+                pattern.clone(),
+                Matcher::new(nucleo_matcher::Config::DEFAULT),
+            ))
+        })
+        .collect();
+
+    // Use the same tree-walker library that ripgrep uses. We use it directly so
+    // that we can leverage the parallelism it provides.
+    let mut walk_builder = WalkBuilder::new(&search_directory);
+    walk_builder.threads(num_walk_builder_threads);
+    if !exclude.is_empty() {
+        let mut override_builder = OverrideBuilder::new(&search_directory);
+        for exclude in exclude {
+            // The `!` prefix is used to indicate an exclude pattern.
+            let exclude_pattern = format!("!{}", exclude);
+            override_builder.add(&exclude_pattern)?;
+        }
+        let override_matcher = override_builder.build()?;
+        walk_builder.overrides(override_matcher);
+    }
+    let walker = walk_builder.build_parallel();
+
+    // Each worker created by `WalkParallel::run()` will have its own
+    // `BestMatchesList` to update.
+    let index_counter = AtomicUsize::new(0);
+    walker.run(|| {
+        let search_directory = search_directory.clone();
+        let index = index_counter.fetch_add(1, Ordering::Relaxed);
+        let best_list_ptr = best_matchers_per_worker[index].get();
+        let best_list = unsafe { &mut *best_list_ptr };
+        Box::new(move |entry| {
+            if let Some(path) = get_file_path(&entry, &search_directory) {
+                best_list.insert(path);
+            }
+            ignore::WalkState::Continue
+        })
+    });
+
+    fn get_file_path<'a>(
+        entry_result: &'a Result<ignore::DirEntry, ignore::Error>,
+        search_directory: &std::path::Path,
+    ) -> Option<&'a str> {
+        let entry = match entry_result {
+            Ok(e) => e,
+            Err(_) => return None,
+        };
+        if entry.file_type().is_some_and(|ft| ft.is_dir()) {
+            return None;
+        }
+        let path = entry.path();
+        match path.strip_prefix(search_directory) {
+            Ok(rel_path) => rel_path.to_str(),
+            Err(_) => None,
+        }
+    }
+
+    // Merge results across best_matchers_per_worker.
+    let mut global_heap: BinaryHeap<Reverse<(u32, String)>> = BinaryHeap::new();
+    let mut total_match_count = 0;
+    for best_list_cell in best_matchers_per_worker.iter() {
+        let best_list = unsafe { &*best_list_cell.get() };
+        total_match_count += best_list.num_matches;
+        for &Reverse((score, ref line)) in best_list.binary_heap.iter() {
+            if global_heap.len() < limit.get() {
+                global_heap.push(Reverse((score, line.clone())));
+            } else if let Some(min_element) = global_heap.peek() {
+                if score > min_element.0.0 {
+                    global_heap.pop();
+                    global_heap.push(Reverse((score, line.clone())));
+                }
+            }
+        }
+    }
+
+    let mut matches: Vec<(u32, String)> = global_heap.into_iter().map(|r| r.0).collect();
+    matches.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+
+    Ok(FileSearchResults {
+        matches,
+        total_match_count,
+    })
+}
+
+/// Maintains the `max_count` best matches for a given pattern.
+struct BestMatchesList {
+    max_count: usize,
+    num_matches: usize,
+    pattern: Pattern,
+    matcher: Matcher,
+    binary_heap: BinaryHeap<Reverse<(u32, String)>>,
+
+    /// Internal buffer for converting strings to UTF-32.
+    utf32buf: Vec<char>,
+}
+
+impl BestMatchesList {
+    fn new(max_count: usize, pattern: Pattern, matcher: Matcher) -> Self {
+        Self {
+            max_count,
+            num_matches: 0,
+            pattern,
+            matcher,
+            binary_heap: BinaryHeap::new(),
+            utf32buf: Vec::<char>::new(),
+        }
+    }
+
+    fn insert(&mut self, line: &str) {
+        let haystack: Utf32Str<'_> = Utf32Str::new(line, &mut self.utf32buf);
+        if let Some(score) = self.pattern.score(haystack, &mut self.matcher) {
+            // In the tests below, we verify that score() returns None for a
+            // non-match, so we can categorically increment the count here.
+            self.num_matches += 1;
+
+            if self.binary_heap.len() < self.max_count {
+                self.binary_heap.push(Reverse((score, line.to_string())));
+            } else if let Some(min_element) = self.binary_heap.peek() {
+                if score > min_element.0.0 {
+                    self.binary_heap.pop();
+                    self.binary_heap.push(Reverse((score, line.to_string())));
+                }
+            }
+        }
+    }
+}
+
+struct WorkerCount {
+    num_walk_builder_threads: usize,
+    num_best_matches_lists: usize,
+}
+
+fn create_worker_count(num_workers: NonZero<usize>) -> WorkerCount {
+    // It appears that the number of times the function passed to
+    // `WalkParallel::run()` is called is: the number of threads specified to
+    // the builder PLUS ONE.
+    //
+    // In `WalkParallel::visit()`, the builder function gets called once here:
+    // https://github.com/BurntSushi/ripgrep/blob/79cbe89deb1151e703f4d91b19af9cdcc128b765/crates/ignore/src/walk.rs#L1233
+    //
+    // And then once for every worker here:
+    // https://github.com/BurntSushi/ripgrep/blob/79cbe89deb1151e703f4d91b19af9cdcc128b765/crates/ignore/src/walk.rs#L1288
+    let num_walk_builder_threads = num_workers.get();
+    let num_best_matches_lists = num_walk_builder_threads + 1;
+
+    WorkerCount {
+        num_walk_builder_threads,
+        num_best_matches_lists,
+    }
+}
+
+fn create_pattern(pattern: &str) -> Pattern {
+    Pattern::new(
+        pattern,
+        CaseMatching::Smart,
+        Normalization::Smart,
+        AtomKind::Fuzzy,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn verify_score_is_none_for_non_match() {
+        let mut utf32buf = Vec::<char>::new();
+        let line = "hello";
+        let mut matcher = Matcher::new(nucleo_matcher::Config::DEFAULT);
+        let haystack: Utf32Str<'_> = Utf32Str::new(line, &mut utf32buf);
+        let pattern = create_pattern("zzz");
+        let score = pattern.score(haystack, &mut matcher);
+        assert_eq!(score, None);
+    }
+}

--- a/codex-rs/file-search/src/lib.rs
+++ b/codex-rs/file-search/src/lib.rs
@@ -183,12 +183,20 @@ pub async fn run(
     }
 
     let mut matches: Vec<(u32, String)> = global_heap.into_iter().map(|r| r.0).collect();
-    matches.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+    sort_matches(&mut matches);
 
     Ok(FileSearchResults {
         matches,
         total_match_count,
     })
+}
+
+/// Sort matches in-place by descending score, then ascending path.
+fn sort_matches(matches: &mut [(u32, String)]) {
+    matches.sort_by(|a, b| match b.0.cmp(&a.0) {
+        std::cmp::Ordering::Equal => a.1.cmp(&b.1),
+        other => other,
+    });
 }
 
 /// Maintains the `max_count` best matches for a given pattern.
@@ -280,5 +288,25 @@ mod tests {
         let pattern = create_pattern("zzz");
         let score = pattern.score(haystack, &mut matcher);
         assert_eq!(score, None);
+    }
+
+    #[test]
+    fn tie_breakers_sort_by_path_when_scores_equal() {
+        let mut matches = vec![
+            (100, "b_path".to_string()),
+            (100, "a_path".to_string()),
+            (90, "zzz".to_string()),
+        ];
+
+        sort_matches(&mut matches);
+
+        // Highest score first; ties broken alphabetically.
+        let expected = vec![
+            (100, "a_path".to_string()),
+            (100, "b_path".to_string()),
+            (90, "zzz".to_string()),
+        ];
+
+        assert_eq!(matches, expected);
     }
 }

--- a/codex-rs/file-search/src/main.rs
+++ b/codex-rs/file-search/src/main.rs
@@ -1,0 +1,50 @@
+use std::path::Path;
+
+use clap::Parser;
+use codex_file_search::Cli;
+use codex_file_search::Reporter;
+use codex_file_search::run_main;
+use serde_json::json;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let cli = Cli::parse();
+    let reporter = StdioReporter {
+        write_output_as_json: cli.json,
+    };
+    run_main(cli, reporter).await?;
+    Ok(())
+}
+
+struct StdioReporter {
+    write_output_as_json: bool,
+}
+
+impl Reporter for StdioReporter {
+    fn report_match(&self, file: &str, score: u32) {
+        if self.write_output_as_json {
+            let value = json!({ "file": file, "score": score });
+            println!("{}", serde_json::to_string(&value).unwrap());
+        } else {
+            println!("{file}");
+        }
+    }
+
+    fn warn_matches_truncated(&self, total_match_count: usize, shown_match_count: usize) {
+        if self.write_output_as_json {
+            let value = json!({"matches_truncated": true});
+            println!("{}", serde_json::to_string(&value).unwrap());
+        } else {
+            eprintln!(
+                "Warning: showing {shown_match_count} out of {total_match_count} results. Provide a more specific pattern or increase the --limit.",
+            );
+        }
+    }
+
+    fn warn_no_search_pattern(&self, search_directory: &Path) {
+        eprintln!(
+            "No search pattern specified. Showing the contents of the current directory ({}):",
+            search_directory.to_string_lossy()
+        );
+    }
+}

--- a/codex-rs/justfile
+++ b/codex-rs/justfile
@@ -16,6 +16,10 @@ exec *args:
 tui *args:
     cargo run --bin codex -- tui "$@"
 
+# Run the CLI version of the file-search crate.
+file-search *args:
+    cargo run --bin codex-file-search -- "$@"
+
 # format code
 fmt:
     cargo fmt -- --config imports_granularity=Item

--- a/codex-rs/linux-sandbox/Cargo.toml
+++ b/codex-rs/linux-sandbox/Cargo.toml
@@ -15,15 +15,9 @@ path = "src/lib.rs"
 workspace = true
 
 [dependencies]
+anyhow = "1"
 clap = { version = "4", features = ["derive"] }
 codex-core = { path = "../core" }
-codex-common = { path = "../common", features = ["cli"] }
-
-# Used for error handling in the helper that unifies runtime dispatch across
-# binaries.
-anyhow = "1"
-# Required to construct a Tokio runtime for async execution of the caller's
-# entry-point.
 tokio = { version = "1", features = ["rt-multi-thread"] }
 
 [dev-dependencies]

--- a/codex-rs/linux-sandbox/src/linux_run_main.rs
+++ b/codex-rs/linux-sandbox/src/linux_run_main.rs
@@ -1,13 +1,16 @@
 use clap::Parser;
-use codex_common::SandboxPermissionOption;
 use std::ffi::CString;
+use std::path::PathBuf;
 
 use crate::landlock::apply_sandbox_policy_to_current_thread;
 
 #[derive(Debug, Parser)]
 pub struct LandlockCommand {
-    #[clap(flatten)]
-    pub sandbox: SandboxPermissionOption,
+    /// It is possible that the cwd used in the context of the sandbox policy
+    /// is different from the cwd of the process to spawn.
+    pub sandbox_policy_cwd: PathBuf,
+
+    pub sandbox_policy: codex_core::protocol::SandboxPolicy,
 
     /// Full command args to run under landlock.
     #[arg(trailing_var_arg = true)]
@@ -15,21 +18,13 @@ pub struct LandlockCommand {
 }
 
 pub fn run_main() -> ! {
-    let LandlockCommand { sandbox, command } = LandlockCommand::parse();
+    let LandlockCommand {
+        sandbox_policy_cwd,
+        sandbox_policy,
+        command,
+    } = LandlockCommand::parse();
 
-    let sandbox_policy = match sandbox.permissions.map(Into::into) {
-        Some(sandbox_policy) => sandbox_policy,
-        None => codex_core::protocol::SandboxPolicy::new_read_only_policy(),
-    };
-
-    let cwd = match std::env::current_dir() {
-        Ok(cwd) => cwd,
-        Err(e) => {
-            panic!("failed to getcwd(): {e:?}");
-        }
-    };
-
-    if let Err(e) = apply_sandbox_policy_to_current_thread(&sandbox_policy, &cwd) {
+    if let Err(e) = apply_sandbox_policy_to_current_thread(&sandbox_policy, &sandbox_policy_cwd) {
         panic!("error running landlock: {e:?}");
     }
 

--- a/codex-rs/linux-sandbox/tests/landlock.rs
+++ b/codex-rs/linux-sandbox/tests/landlock.rs
@@ -46,7 +46,10 @@ async fn run_cmd(cmd: &[&str], writable_roots: &[PathBuf], timeout_ms: u64) {
         env: create_env_from_core_vars(),
     };
 
-    let sandbox_policy = SandboxPolicy::new_read_only_policy_with_writable_roots(writable_roots);
+    let sandbox_policy = SandboxPolicy::WorkspaceWrite {
+        writable_roots: writable_roots.to_vec(),
+        network_access: false,
+    };
     let sandbox_program = env!("CARGO_BIN_EXE_codex-linux-sandbox");
     let codex_linux_sandbox_exe = Some(PathBuf::from(sandbox_program));
     let ctrl_c = Arc::new(Notify::new());

--- a/codex-rs/mcp-server/src/codex_tool_config.rs
+++ b/codex-rs/mcp-server/src/codex_tool_config.rs
@@ -47,8 +47,7 @@ pub(crate) struct CodexToolCallParam {
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub(crate) enum CodexToolCallApprovalPolicy {
-    AutoEdit,
-    UnlessAllowListed,
+    Untrusted,
     OnFailure,
     Never,
 }
@@ -56,8 +55,7 @@ pub(crate) enum CodexToolCallApprovalPolicy {
 impl From<CodexToolCallApprovalPolicy> for AskForApproval {
     fn from(value: CodexToolCallApprovalPolicy) -> Self {
         match value {
-            CodexToolCallApprovalPolicy::AutoEdit => AskForApproval::AutoEdit,
-            CodexToolCallApprovalPolicy::UnlessAllowListed => AskForApproval::UnlessAllowListed,
+            CodexToolCallApprovalPolicy::Untrusted => AskForApproval::UnlessAllowListed,
             CodexToolCallApprovalPolicy::OnFailure => AskForApproval::OnFailure,
             CodexToolCallApprovalPolicy::Never => AskForApproval::Never,
         }
@@ -164,8 +162,7 @@ mod tests {
               "approval-policy": {
                 "description": "Execution approval policy expressed as the kebab-case variant name (`unless-allow-listed`, `auto-edit`, `on-failure`, `never`).",
                 "enum": [
-                  "auto-edit",
-                  "unless-allow-listed",
+                  "untrusted",
                   "on-failure",
                   "never"
                 ],

--- a/codex-rs/mcp-server/src/codex_tool_config.rs
+++ b/codex-rs/mcp-server/src/codex_tool_config.rs
@@ -55,7 +55,7 @@ pub(crate) enum CodexToolCallApprovalPolicy {
 impl From<CodexToolCallApprovalPolicy> for AskForApproval {
     fn from(value: CodexToolCallApprovalPolicy) -> Self {
         match value {
-            CodexToolCallApprovalPolicy::Untrusted => AskForApproval::UnlessAllowListed,
+            CodexToolCallApprovalPolicy::Untrusted => AskForApproval::UnlessTrusted,
             CodexToolCallApprovalPolicy::OnFailure => AskForApproval::OnFailure,
             CodexToolCallApprovalPolicy::Never => AskForApproval::Never,
         }

--- a/codex-rs/mcp-server/src/codex_tool_config.rs
+++ b/codex-rs/mcp-server/src/codex_tool_config.rs
@@ -1,7 +1,6 @@
 //! Configuration object accepted by the `codex` MCP tool-call.
 
 use codex_core::protocol::AskForApproval;
-use codex_core::protocol::SandboxPolicy;
 use mcp_types::Tool;
 use mcp_types::ToolInputSchema;
 use schemars::JsonSchema;
@@ -19,7 +18,7 @@ pub(crate) struct CodexToolCallParam {
     /// The *initial user prompt* to start the Codex conversation.
     pub prompt: String,
 
-    /// Optional override for the model name (e.g. "o3", "o4-mini")
+    /// Optional override for the model name (e.g. "o3", "o4-mini").
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
 
@@ -37,22 +36,14 @@ pub(crate) struct CodexToolCallParam {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub approval_policy: Option<CodexToolCallApprovalPolicy>,
 
-    /// Sandbox permissions using the same string values accepted by the CLI
-    /// (e.g. "disk-write-cwd", "network-full-access").
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub sandbox_permissions: Option<Vec<CodexToolCallSandboxPermission>>,
-
     /// Individual config settings that will override what is in
     /// CODEX_HOME/config.toml.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub config: Option<HashMap<String, serde_json::Value>>,
 }
 
-// Create custom enums for use with `CodexToolCallApprovalPolicy` where we
-// intentionally exclude docstrings from the generated schema because they
-// introduce anyOf in the the generated JSON schema, which makes it more complex
-// without adding any real value since we aspire to use self-descriptive names.
-
+// Custom enum mirroring `AskForApproval`, but constrained to the subset we
+// expose via the tool-call schema.
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub(crate) enum CodexToolCallApprovalPolicy {
@@ -73,50 +64,12 @@ impl From<CodexToolCallApprovalPolicy> for AskForApproval {
     }
 }
 
-// TODO: Support additional writable folders via a separate property on
-// CodexToolCallParam.
-
-#[derive(Debug, Clone, Deserialize, JsonSchema)]
-#[serde(rename_all = "kebab-case")]
-pub(crate) enum CodexToolCallSandboxPermission {
-    DiskFullReadAccess,
-    DiskWriteCwd,
-    DiskWritePlatformUserTempFolder,
-    DiskWritePlatformGlobalTempFolder,
-    DiskFullWriteAccess,
-    NetworkFullAccess,
-}
-
-impl From<CodexToolCallSandboxPermission> for codex_core::protocol::SandboxPermission {
-    fn from(value: CodexToolCallSandboxPermission) -> Self {
-        match value {
-            CodexToolCallSandboxPermission::DiskFullReadAccess => {
-                codex_core::protocol::SandboxPermission::DiskFullReadAccess
-            }
-            CodexToolCallSandboxPermission::DiskWriteCwd => {
-                codex_core::protocol::SandboxPermission::DiskWriteCwd
-            }
-            CodexToolCallSandboxPermission::DiskWritePlatformUserTempFolder => {
-                codex_core::protocol::SandboxPermission::DiskWritePlatformUserTempFolder
-            }
-            CodexToolCallSandboxPermission::DiskWritePlatformGlobalTempFolder => {
-                codex_core::protocol::SandboxPermission::DiskWritePlatformGlobalTempFolder
-            }
-            CodexToolCallSandboxPermission::DiskFullWriteAccess => {
-                codex_core::protocol::SandboxPermission::DiskFullWriteAccess
-            }
-            CodexToolCallSandboxPermission::NetworkFullAccess => {
-                codex_core::protocol::SandboxPermission::NetworkFullAccess
-            }
-        }
-    }
-}
-
+/// Builds a `Tool` definition (JSON schema etc.) for the Codex tool-call.
 pub(crate) fn create_tool_for_codex_tool_call_param() -> Tool {
     let schema = SchemaSettings::draft2019_09()
         .with(|s| {
             s.inline_subschemas = true;
-            s.option_add_null_type = false
+            s.option_add_null_type = false;
         })
         .into_generator()
         .into_root_schema_for::<CodexToolCallParam>();
@@ -129,12 +82,12 @@ pub(crate) fn create_tool_for_codex_tool_call_param() -> Tool {
         serde_json::from_value::<ToolInputSchema>(schema_value).unwrap_or_else(|e| {
             panic!("failed to create Tool from schema: {e}");
         });
+
     Tool {
         name: "codex".to_string(),
         input_schema: tool_input_schema,
         description: Some(
-            "Run a Codex session. Accepts configuration parameters matching the Codex Config struct."
-                .to_string(),
+            "Run a Codex session. Accepts configuration parameters matching the Codex Config struct.".to_string(),
         ),
         annotations: None,
     }
@@ -142,7 +95,7 @@ pub(crate) fn create_tool_for_codex_tool_call_param() -> Tool {
 
 impl CodexToolCallParam {
     /// Returns the initial user prompt to start the Codex conversation and the
-    /// Config.
+    /// effective Config object generated from the supplied parameters.
     pub fn into_config(
         self,
         codex_linux_sandbox_exe: Option<PathBuf>,
@@ -153,20 +106,18 @@ impl CodexToolCallParam {
             profile,
             cwd,
             approval_policy,
-            sandbox_permissions,
             config: cli_overrides,
         } = self;
-        let sandbox_policy = sandbox_permissions.map(|perms| {
-            SandboxPolicy::from(perms.into_iter().map(Into::into).collect::<Vec<_>>())
-        });
 
-        // Build ConfigOverrides recognised by codex-core.
+        // Build the `ConfigOverrides` recognised by codex-core.
         let overrides = codex_core::config::ConfigOverrides {
             model,
             config_profile: profile,
             cwd: cwd.map(PathBuf::from),
             approval_policy: approval_policy.map(Into::into),
-            sandbox_policy,
+            // Note we may want to expose a field on CodexToolCallParam to
+            // facilitate configuring the sandbox policy.
+            sandbox_policy: None,
             model_provider: None,
             codex_linux_sandbox_exe,
         };
@@ -230,7 +181,7 @@ mod tests {
                 "type": "string"
               },
               "model": {
-                "description": "Optional override for the model name (e.g. \"o3\", \"o4-mini\")",
+                "description": "Optional override for the model name (e.g. \"o3\", \"o4-mini\").",
                 "type": "string"
               },
               "profile": {
@@ -241,21 +192,6 @@ mod tests {
                 "description": "The *initial user prompt* to start the Codex conversation.",
                 "type": "string"
               },
-              "sandbox-permissions": {
-                "description": "Sandbox permissions using the same string values accepted by the CLI (e.g. \"disk-write-cwd\", \"network-full-access\").",
-                "items": {
-                  "enum": [
-                    "disk-full-read-access",
-                    "disk-write-cwd",
-                    "disk-write-platform-user-temp-folder",
-                    "disk-write-platform-global-temp-folder",
-                    "disk-full-write-access",
-                    "network-full-access"
-                  ],
-                  "type": "string"
-                },
-                "type": "array"
-              }
             },
             "required": [
               "prompt"

--- a/codex-rs/mcp-server/src/codex_tool_runner.rs
+++ b/codex-rs/mcp-server/src/codex_tool_runner.rs
@@ -162,6 +162,7 @@ pub async fn run_codex_tool_session(
                     }
                     EventMsg::Error(_)
                     | EventMsg::TaskStarted
+                    | EventMsg::TokenCount(_)
                     | EventMsg::AgentReasoning(_)
                     | EventMsg::McpToolCallBegin(_)
                     | EventMsg::McpToolCallEnd(_)

--- a/codex-rs/scripts/create_github_release.sh
+++ b/codex-rs/scripts/create_github_release.sh
@@ -28,10 +28,19 @@ else
   VERSION=$(printf '0.0.%d' "$(date +%y%m%d%H%M)")
 fi
 TAG="rust-v$VERSION"
+RELEASE_BRANCH="release/$TAG"
+
 git checkout -b "$TAG"
 perl -i -pe "s/^version = \".*\"/version = \"$VERSION\"/" Cargo.toml
 git add Cargo.toml
 git commit -m "Release $VERSION"
 git tag -a "$TAG" -m "Release $VERSION"
+
+# The commit identified by the tag must be reachable from a branch so that
+# when GitHub creates the `Source code (tar.gz)` for the release, it can find
+# the commit. This is a requirement for Homebrew to be able to install the
+# package from the tarball.
+git push origin "$RELEASE_BRANCH"
 git push origin "refs/tags/$TAG"
+
 git checkout "$CURRENT_BRANCH"

--- a/codex-rs/scripts/create_github_release.sh
+++ b/codex-rs/scripts/create_github_release.sh
@@ -28,19 +28,11 @@ else
   VERSION=$(printf '0.0.%d' "$(date +%y%m%d%H%M)")
 fi
 TAG="rust-v$VERSION"
-RELEASE_BRANCH="release/$TAG"
-
-git checkout -b "$RELEASE_BRANCH"
+git checkout -b "$TAG"
 perl -i -pe "s/^version = \".*\"/version = \"$VERSION\"/" Cargo.toml
 git add Cargo.toml
 git commit -m "Release $VERSION"
 git tag -a "$TAG" -m "Release $VERSION"
-
-# The commit identified by the tag must be reachable from a branch so that
-# when GitHub creates the `Source code (tar.gz)` for the release, it can find
-# the commit. This is a requirement for Homebrew to be able to install the
-# package from the tarball.
-git push origin "$RELEASE_BRANCH"
 git push origin "refs/tags/$TAG"
 
 git checkout "$CURRENT_BRANCH"

--- a/codex-rs/scripts/create_github_release.sh
+++ b/codex-rs/scripts/create_github_release.sh
@@ -30,7 +30,7 @@ fi
 TAG="rust-v$VERSION"
 RELEASE_BRANCH="release/$TAG"
 
-git checkout -b "$TAG"
+git checkout -b "$RELEASE_BRANCH"
 perl -i -pe "s/^version = \".*\"/version = \"$VERSION\"/" Cargo.toml
 git add Cargo.toml
 git commit -m "Release $VERSION"

--- a/codex-rs/scripts/create_github_release.sh
+++ b/codex-rs/scripts/create_github_release.sh
@@ -2,6 +2,13 @@
 
 set -euo pipefail
 
+# By default, this script uses a version based on the current date and time.
+# If you want to specify a version, pass it as the first argument. Example:
+#
+#     ./scripts/create_github_release.sh 0.1.0-alpha.4
+#
+# The value will be used to update the `version` field in `Cargo.toml`.
+
 # Change to the root of the Cargo workspace.
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
@@ -15,7 +22,11 @@ fi
 CURRENT_BRANCH=$(git symbolic-ref --short -q HEAD)
 
 # Create a new branch for the release and make a commit with the new version.
-VERSION=$(printf '0.0.%d' "$(date +%y%m%d%H%M)")
+if [ $# -ge 1 ]; then
+  VERSION="$1"
+else
+  VERSION=$(printf '0.0.%d' "$(date +%y%m%d%H%M)")
+fi
 TAG="rust-v$VERSION"
 git checkout -b "$TAG"
 perl -i -pe "s/^version = \".*\"/version = \"$VERSION\"/" Cargo.toml

--- a/codex-rs/tui/Cargo.toml
+++ b/codex-rs/tui/Cargo.toml
@@ -25,6 +25,7 @@ codex-common = { path = "../common", features = [
     "elapsed",
     "sandbox_summary",
 ] }
+codex-file-search = { path = "../file-search" }
 codex-linux-sandbox = { path = "../linux-sandbox" }
 codex-login = { path = "../login" }
 color-eyre = "0.6.3"

--- a/codex-rs/tui/Cargo.toml
+++ b/codex-rs/tui/Cargo.toml
@@ -20,7 +20,11 @@ base64 = "0.22.1"
 clap = { version = "4", features = ["derive"] }
 codex-ansi-escape = { path = "../ansi-escape" }
 codex-core = { path = "../core" }
-codex-common = { path = "../common", features = ["cli", "elapsed"] }
+codex-common = { path = "../common", features = [
+    "cli",
+    "elapsed",
+    "sandbox_summary",
+] }
 codex-linux-sandbox = { path = "../linux-sandbox" }
 codex-login = { path = "../login" }
 color-eyre = "0.6.3"

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -11,7 +11,6 @@ use crate::slash_command::SlashCommand;
 use crate::tui;
 use codex_core::config::Config;
 use codex_core::protocol::Event;
-use codex_core::protocol::Op;
 use color_eyre::eyre::Result;
 use crossterm::event::KeyCode;
 use crossterm::event::KeyEvent;
@@ -193,10 +192,11 @@ impl<'a> App<'a> {
                             modifiers: crossterm::event::KeyModifiers::CONTROL,
                             ..
                         } => {
-                            // Forward interrupt to ChatWidget when active.
                             match &mut self.app_state {
                                 AppState::Chat { widget } => {
-                                    widget.submit_op(Op::Interrupt);
+                                    if widget.on_ctrl_c() {
+                                        self.app_event_tx.send(AppEvent::ExitRequest);
+                                    }
                                 }
                                 AppState::Login { .. } | AppState::GitWarning { .. } => {
                                     // No-op.

--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -28,4 +28,17 @@ pub(crate) enum AppEvent {
     /// Dispatch a recognized slash command from the UI (composer) to the app
     /// layer so it can be handled centrally.
     DispatchCommand(SlashCommand),
+
+    /// Kick off an asynchronous file search for the given query (text after
+    /// the `@`). Previous searches may be cancelled by the app layer so there
+    /// is at most one in-flight search.
+    StartFileSearch(String),
+
+    /// Result of a completed asynchronous file search. The `query` echoes the
+    /// original search term so the UI can decide whether the results are
+    /// still relevant.
+    FileSearchResult {
+        query: String,
+        matches: Vec<String>,
+    },
 }

--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -1,4 +1,5 @@
 use codex_core::protocol::Event;
+use codex_file_search::FileMatch;
 use crossterm::event::KeyEvent;
 
 use crate::slash_command::SlashCommand;
@@ -39,6 +40,6 @@ pub(crate) enum AppEvent {
     /// still relevant.
     FileSearchResult {
         query: String,
-        matches: Vec<String>,
+        matches: Vec<FileMatch>,
     },
 }

--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -20,6 +20,7 @@ use super::file_search_popup::FileSearchPopup;
 
 use crate::app_event::AppEvent;
 use crate::app_event_sender::AppEventSender;
+use codex_file_search::FileMatch;
 
 /// Minimum number of visible text rows inside the textarea.
 const MIN_TEXTAREA_ROWS: usize = 1;
@@ -129,7 +130,7 @@ impl ChatComposer<'_> {
     }
 
     /// Integrate results from an asynchronous file search.
-    pub(crate) fn on_file_search_result(&mut self, query: String, matches: Vec<String>) {
+    pub(crate) fn on_file_search_result(&mut self, query: String, matches: Vec<FileMatch>) {
         // Only apply if user is still editing a token starting with `query`.
         let current_opt = Self::current_at_token(&self.textarea);
         let Some(current_token) = current_opt else {

--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -38,6 +38,7 @@ pub(crate) struct ChatComposer<'a> {
     command_popup: Option<CommandPopup>,
     app_event_tx: AppEventSender,
     history: ChatComposerHistory,
+    ctrl_c_quit_hint: bool,
 }
 
 impl ChatComposer<'_> {
@@ -51,6 +52,7 @@ impl ChatComposer<'_> {
             command_popup: None,
             app_event_tx,
             history: ChatComposerHistory::new(),
+            ctrl_c_quit_hint: false,
         };
         this.update_border(has_input_focus);
         this
@@ -111,6 +113,11 @@ impl ChatComposer<'_> {
     }
 
     pub fn set_input_focus(&mut self, has_focus: bool) {
+        self.update_border(has_focus);
+    }
+
+    pub fn set_ctrl_c_quit_hint(&mut self, show: bool, has_focus: bool) {
+        self.ctrl_c_quit_hint = show;
         self.update_border(has_focus);
     }
 
@@ -304,10 +311,17 @@ impl ChatComposer<'_> {
         }
 
         let bs = if has_focus {
-            BlockState {
-                right_title: Line::from("Enter to send | Ctrl+D to quit | Ctrl+J for newline")
-                    .alignment(Alignment::Right),
-                border_style: Style::default(),
+            if self.ctrl_c_quit_hint {
+                BlockState {
+                    right_title: Line::from("Ctrl+C to quit").alignment(Alignment::Right),
+                    border_style: Style::default(),
+                }
+            } else {
+                BlockState {
+                    right_title: Line::from("Enter to send | Ctrl+D to quit | Ctrl+J for newline")
+                        .alignment(Alignment::Right),
+                    border_style: Style::default(),
+                }
             }
         } else {
             BlockState {

--- a/codex-rs/tui/src/bottom_pane/command_popup.rs
+++ b/codex-rs/tui/src/bottom_pane/command_popup.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
 use ratatui::style::Color;
@@ -25,7 +23,7 @@ use ratatui::style::Modifier;
 
 pub(crate) struct CommandPopup {
     command_filter: String,
-    all_commands: HashMap<&'static str, SlashCommand>,
+    all_commands: Vec<(&'static str, SlashCommand)>,
     selected_idx: Option<usize>,
 }
 
@@ -84,23 +82,20 @@ impl CommandPopup {
     /// Return the list of commands that match the current filter. Matching is
     /// performed using a *prefix* comparison on the command name.
     fn filtered_commands(&self) -> Vec<&SlashCommand> {
-        let mut cmds: Vec<&SlashCommand> = self
-            .all_commands
-            .values()
-            .filter(|cmd| {
-                if self.command_filter.is_empty() {
-                    true
-                } else {
-                    cmd.command()
+        self.all_commands
+            .iter()
+            .filter_map(|(_name, cmd)| {
+                if self.command_filter.is_empty()
+                    || cmd
+                        .command()
                         .starts_with(&self.command_filter.to_ascii_lowercase())
+                {
+                    Some(cmd)
+                } else {
+                    None
                 }
             })
-            .collect();
-
-        // Sort the commands alphabetically so the order is stable and
-        // predictable.
-        cmds.sort_by(|a, b| a.command().cmp(b.command()));
-        cmds
+            .collect::<Vec<&SlashCommand>>()
     }
 
     /// Move the selection cursor one step up.

--- a/codex-rs/tui/src/bottom_pane/file_search_popup.rs
+++ b/codex-rs/tui/src/bottom_pane/file_search_popup.rs
@@ -1,0 +1,159 @@
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::prelude::Constraint;
+use ratatui::style::Color;
+use ratatui::style::Style;
+use ratatui::widgets::Block;
+use ratatui::widgets::BorderType;
+use ratatui::widgets::Borders;
+use ratatui::widgets::Cell;
+use ratatui::widgets::Row;
+use ratatui::widgets::Table;
+use ratatui::widgets::Widget;
+use ratatui::widgets::WidgetRef;
+
+/// Maximum number of suggestions shown in the popup.
+const MAX_RESULTS: usize = 8;
+
+/// Visual state for the file-search popup.
+pub(crate) struct FileSearchPopup {
+    /// Query corresponding to the `matches` currently shown.
+    display_query: String,
+    /// Latest query typed by the user. May differ from `display_query` when
+    /// a search is still in-flight.
+    pending_query: String,
+    /// When `true` we are still waiting for results for `pending_query`.
+    waiting: bool,
+    /// Cached matches; paths relative to the search dir.
+    matches: Vec<String>,
+    /// Currently selected index inside `matches` (if any).
+    selected_idx: Option<usize>,
+}
+
+impl FileSearchPopup {
+    pub(crate) fn new() -> Self {
+        Self {
+            display_query: String::new(),
+            pending_query: String::new(),
+            waiting: true,
+            matches: Vec::new(),
+            selected_idx: None,
+        }
+    }
+
+    /// Update the query and reset state to *waiting*.
+    pub(crate) fn set_query(&mut self, query: &str) {
+        if query == self.pending_query {
+            return;
+        }
+
+        // Determine if current matches are still relevant.
+        let keep_existing = query.starts_with(&self.display_query);
+
+        self.pending_query.clear();
+        self.pending_query.push_str(query);
+
+        self.waiting = true; // waiting for new results
+
+        if !keep_existing {
+            self.matches.clear();
+            self.selected_idx = None;
+        }
+    }
+
+    /// Replace matches when a `FileSearchResult` arrives.
+    /// Replace matches. Only applied when `query` matches `pending_query`.
+    pub(crate) fn set_matches(&mut self, query: &str, matches: Vec<String>) {
+        if query != self.pending_query {
+            return; // stale
+        }
+
+        self.display_query = query.to_string();
+        self.matches = matches;
+        self.waiting = false;
+        self.selected_idx = if self.matches.is_empty() {
+            None
+        } else {
+            Some(0)
+        };
+    }
+
+    /// Move selection cursor up.
+    pub(crate) fn move_up(&mut self) {
+        if let Some(idx) = self.selected_idx {
+            if idx > 0 {
+                self.selected_idx = Some(idx - 1);
+            }
+        }
+    }
+
+    /// Move selection cursor down.
+    pub(crate) fn move_down(&mut self) {
+        if let Some(idx) = self.selected_idx {
+            if idx + 1 < self.matches.len() {
+                self.selected_idx = Some(idx + 1);
+            }
+        } else if !self.matches.is_empty() {
+            self.selected_idx = Some(0);
+        }
+    }
+
+    pub(crate) fn selected_match(&self) -> Option<&str> {
+        self.selected_idx
+            .and_then(|idx| self.matches.get(idx))
+            .map(String::as_str)
+    }
+
+    /// Preferred height (rows) including border.
+    pub(crate) fn calculate_required_height(&self, _area: &Rect) -> u16 {
+        // Row count depends on whether we already have matches. If no matches
+        // yet (e.g. initial search or query with no results) reserve a single
+        // row so the popup is still visible. When matches are present we show
+        // up to MAX_RESULTS regardless of the waiting flag so the list
+        // remains stable while a newer search is in-flight.
+        let rows = if self.matches.is_empty() {
+            1
+        } else {
+            self.matches.len().clamp(1, MAX_RESULTS)
+        } as u16;
+        rows + 2 // border
+    }
+}
+
+impl WidgetRef for &FileSearchPopup {
+    fn render_ref(&self, area: Rect, buf: &mut Buffer) {
+        // Prepare rows.
+        let rows: Vec<Row> = if self.matches.is_empty() {
+            vec![Row::new(vec![Cell::from(" no matches ")])]
+        } else {
+            self.matches
+                .iter()
+                .take(MAX_RESULTS)
+                .enumerate()
+                .map(|(i, p)| {
+                    let mut cell = Cell::from(p.as_str());
+                    if Some(i) == self.selected_idx {
+                        cell = cell.style(Style::default().fg(Color::Yellow));
+                    }
+                    Row::new(vec![cell])
+                })
+                .collect()
+        };
+
+        let mut title = format!(" @{} ", self.pending_query);
+        if self.waiting {
+            title.push_str(" (searching …)");
+        }
+
+        let table = Table::new(rows, vec![Constraint::Percentage(100)])
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .border_type(BorderType::Rounded)
+                    .title(title),
+            )
+            .widths([Constraint::Percentage(100)]);
+
+        table.render(area, buf);
+    }
+}

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -17,6 +17,7 @@ mod bottom_pane_view;
 mod chat_composer;
 mod chat_composer_history;
 mod command_popup;
+mod file_search_popup;
 mod status_indicator_view;
 
 pub(crate) use chat_composer::ChatComposer;
@@ -201,9 +202,9 @@ impl BottomPane<'_> {
         self.app_event_tx.send(AppEvent::Redraw)
     }
 
-    /// Returns true when the slash-command popup inside the composer is visible.
-    pub(crate) fn is_command_popup_visible(&self) -> bool {
-        self.active_view.is_none() && self.composer.is_command_popup_visible()
+    /// Returns true when a popup inside the composer is visible.
+    pub(crate) fn is_popup_visible(&self) -> bool {
+        self.active_view.is_none() && self.composer.is_popup_visible()
     }
 
     // --- History helpers ---
@@ -225,6 +226,11 @@ impl BottomPane<'_> {
         if updated {
             self.request_redraw();
         }
+    }
+
+    pub(crate) fn on_file_search_result(&mut self, query: String, matches: Vec<String>) {
+        self.composer.on_file_search_result(query, matches);
+        self.request_redraw();
     }
 }
 

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -2,6 +2,7 @@
 
 use bottom_pane_view::BottomPaneView;
 use bottom_pane_view::ConditionalUpdate;
+use codex_core::protocol::TokenUsage;
 use crossterm::event::KeyEvent;
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
@@ -127,6 +128,18 @@ impl BottomPane<'_> {
                 // No change.
             }
         }
+    }
+
+    /// Update the *context-window remaining* indicator in the composer. This
+    /// is forwarded directly to the underlying `ChatComposer`.
+    pub(crate) fn set_token_usage(
+        &mut self,
+        token_usage: TokenUsage,
+        model_context_window: Option<u64>,
+    ) {
+        self.composer
+            .set_token_usage(token_usage, model_context_window);
+        self.request_redraw();
     }
 
     /// Called when the agent requests user approval.

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -1,16 +1,16 @@
 //! Bottom pane: shows the ChatComposer or a BottomPaneView, if one is active.
 
+use crate::app_event::AppEvent;
+use crate::app_event_sender::AppEventSender;
+use crate::user_approval_widget::ApprovalRequest;
 use bottom_pane_view::BottomPaneView;
 use bottom_pane_view::ConditionalUpdate;
 use codex_core::protocol::TokenUsage;
+use codex_file_search::FileMatch;
 use crossterm::event::KeyEvent;
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
 use ratatui::widgets::WidgetRef;
-
-use crate::app_event::AppEvent;
-use crate::app_event_sender::AppEventSender;
-use crate::user_approval_widget::ApprovalRequest;
 
 mod approval_modal_view;
 mod bottom_pane_view;
@@ -228,7 +228,7 @@ impl BottomPane<'_> {
         }
     }
 
-    pub(crate) fn on_file_search_result(&mut self, query: String, matches: Vec<String>) {
+    pub(crate) fn on_file_search_result(&mut self, query: String, matches: Vec<FileMatch>) {
         self.composer.on_file_search_result(query, matches);
         self.request_redraw();
     }

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -37,6 +37,7 @@ pub(crate) struct BottomPane<'a> {
     app_event_tx: AppEventSender,
     has_input_focus: bool,
     is_task_running: bool,
+    ctrl_c_quit_hint: bool,
 }
 
 pub(crate) struct BottomPaneParams {
@@ -52,6 +53,7 @@ impl BottomPane<'_> {
             app_event_tx: params.app_event_tx,
             has_input_focus: params.has_input_focus,
             is_task_running: false,
+            ctrl_c_quit_hint: false,
         }
     }
 
@@ -100,6 +102,26 @@ impl BottomPane<'_> {
         self.composer.set_input_focus(has_focus);
     }
 
+    pub(crate) fn show_ctrl_c_quit_hint(&mut self) {
+        self.ctrl_c_quit_hint = true;
+        self.composer
+            .set_ctrl_c_quit_hint(true, self.has_input_focus);
+        self.request_redraw();
+    }
+
+    pub(crate) fn clear_ctrl_c_quit_hint(&mut self) {
+        if self.ctrl_c_quit_hint {
+            self.ctrl_c_quit_hint = false;
+            self.composer
+                .set_ctrl_c_quit_hint(false, self.has_input_focus);
+            self.request_redraw();
+        }
+    }
+
+    pub(crate) fn ctrl_c_quit_hint_visible(&self) -> bool {
+        self.ctrl_c_quit_hint
+    }
+
     pub fn set_task_running(&mut self, running: bool) {
         self.is_task_running = running;
 
@@ -128,6 +150,10 @@ impl BottomPane<'_> {
                 // No change.
             }
         }
+    }
+
+    pub(crate) fn is_task_running(&self) -> bool {
+        self.is_task_running
     }
 
     /// Update the *context-window remaining* indicator in the composer. This

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -384,6 +384,11 @@ impl ChatWidget<'_> {
         self.app_event_tx.send(AppEvent::Redraw);
     }
 
+    pub(crate) fn add_diff_output(&mut self, diff_output: String) {
+        self.conversation_history.add_diff_output(diff_output);
+        self.request_redraw();
+    }
+
     pub(crate) fn handle_scroll_delta(&mut self, scroll_delta: i32) {
         // If the user is trying to scroll exactly one line, we let them, but
         // otherwise we assume they are trying to scroll in larger increments.

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -143,7 +143,7 @@ impl ChatWidget<'_> {
         // However, when the slash-command popup is visible we forward the key
         // to the bottom pane so it can handle auto-completion.
         if matches!(key_event.code, crossterm::event::KeyCode::Tab)
-            && !self.bottom_pane.is_command_popup_visible()
+            && !self.bottom_pane.is_popup_visible()
         {
             self.input_focus = match self.input_focus {
                 InputFocus::HistoryPane => InputFocus::BottomPane,
@@ -402,6 +402,11 @@ impl ChatWidget<'_> {
         };
         self.conversation_history.scroll(magnified_scroll_delta);
         self.request_redraw();
+    }
+
+    /// Forward file-search results to the bottom pane.
+    pub(crate) fn apply_file_search_result(&mut self, query: String, matches: Vec<String>) {
+        self.bottom_pane.on_file_search_result(query, matches);
     }
 
     /// Handle Ctrl-C key press.

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -38,6 +38,7 @@ use crate::bottom_pane::InputResult;
 use crate::conversation_history_widget::ConversationHistoryWidget;
 use crate::history_cell::PatchEventType;
 use crate::user_approval_widget::ApprovalRequest;
+use codex_file_search::FileMatch;
 
 pub(crate) struct ChatWidget<'a> {
     app_event_tx: AppEventSender,
@@ -405,7 +406,7 @@ impl ChatWidget<'_> {
     }
 
     /// Forward file-search results to the bottom pane.
-    pub(crate) fn apply_file_search_result(&mut self, query: String, matches: Vec<String>) {
+    pub(crate) fn apply_file_search_result(&mut self, query: String, matches: Vec<FileMatch>) {
         self.bottom_pane.on_file_search_result(query, matches);
     }
 

--- a/codex-rs/tui/src/cli.rs
+++ b/codex-rs/tui/src/cli.rs
@@ -25,7 +25,7 @@ pub struct Cli {
     #[arg(long = "ask-for-approval", short = 'a')]
     pub approval_policy: Option<ApprovalModeCliArg>,
 
-    /// Convenience alias for low-friction sandboxed automatic execution (-a on-failure, network-disabled sandbox that can write to cwd and TMPDIR)
+    /// Convenience alias for low-friction sandboxed automatic execution (-a on-failure, -c sandbox.mode=workspace-write).
     #[arg(long = "full-auto", default_value_t = false)]
     pub full_auto: bool,
 

--- a/codex-rs/tui/src/cli.rs
+++ b/codex-rs/tui/src/cli.rs
@@ -1,7 +1,6 @@
 use clap::Parser;
 use codex_common::ApprovalModeCliArg;
 use codex_common::CliConfigOverrides;
-use codex_common::SandboxPermissionOption;
 use std::path::PathBuf;
 
 #[derive(Parser, Debug)]
@@ -29,9 +28,6 @@ pub struct Cli {
     /// Convenience alias for low-friction sandboxed automatic execution (-a on-failure, network-disabled sandbox that can write to cwd and TMPDIR)
     #[arg(long = "full-auto", default_value_t = false)]
     pub full_auto: bool,
-
-    #[clap(flatten)]
-    pub sandbox: SandboxPermissionOption,
 
     /// Tell the agent to use the specified directory as its working root.
     #[clap(long = "cd", short = 'C', value_name = "DIR")]

--- a/codex-rs/tui/src/cli.rs
+++ b/codex-rs/tui/src/cli.rs
@@ -29,6 +29,15 @@ pub struct Cli {
     #[arg(long = "full-auto", default_value_t = false)]
     pub full_auto: bool,
 
+    /// Skip all confirmation prompts and execute commands without sandboxing.
+    /// EXTREMELY DANGEROUS. Intended solely for running in environments that are externally sandboxed.
+    #[arg(
+        long = "dangerously-bypass-approvals-and-sandbox",
+        default_value_t = false,
+        conflicts_with_all = ["approval_policy", "full_auto"]
+    )]
+    pub dangerously_bypass_approvals_and_sandbox: bool,
+
     /// Tell the agent to use the specified directory as its working root.
     #[clap(long = "cd", short = 'C', value_name = "DIR")]
     pub cwd: Option<PathBuf>,

--- a/codex-rs/tui/src/conversation_history_widget.rs
+++ b/codex-rs/tui/src/conversation_history_widget.rs
@@ -206,6 +206,10 @@ impl ConversationHistoryWidget {
         self.add_to_history(HistoryCell::new_background_event(message));
     }
 
+    pub fn add_diff_output(&mut self, diff_output: String) {
+        self.add_to_history(HistoryCell::new_diff_output(diff_output));
+    }
+
     pub fn add_error(&mut self, message: String) {
         self.add_to_history(HistoryCell::new_error_event(message));
     }

--- a/codex-rs/tui/src/file_search.rs
+++ b/codex-rs/tui/src/file_search.rs
@@ -1,0 +1,204 @@
+//! Helper that owns the debounce/cancellation logic for `@` file searches.
+//!
+//! `ChatComposer` publishes *every* change of the `@token` as
+//! `AppEvent::StartFileSearch(query)`.
+//! This struct receives those events and decides when to actually spawn the
+//! expensive search (handled in the main `App` thread). It tries to ensure:
+//!
+//! - Even when the user types long text quickly, they will start seeing results
+//!   after a short delay using an early version of what they typed.
+//! - At most one search is in-flight at any time.
+//!
+//! It works as follows:
+//!
+//! 1. First query starts a debounce timer.
+//! 2. While the timer is pending, the latest query from the user is stored.
+//! 3. When the timer fires, it is cleared, and a search is done for the most
+//!    recent query.
+//! 4. If there is a in-flight search that is not a prefix of the latest thing
+//!    the user typed, it is cancelled.
+
+use codex_file_search as file_search;
+use std::num::NonZeroUsize;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::thread;
+use std::time::Duration;
+
+use crate::app_event::AppEvent;
+use crate::app_event_sender::AppEventSender;
+
+#[allow(clippy::unwrap_used)]
+const MAX_FILE_SEARCH_RESULTS: NonZeroUsize = NonZeroUsize::new(8).unwrap();
+
+#[allow(clippy::unwrap_used)]
+const NUM_FILE_SEARCH_THREADS: NonZeroUsize = NonZeroUsize::new(2).unwrap();
+
+/// How long to wait after a keystroke before firing the first search when none
+/// is currently running. Keeps early queries more meaningful.
+const FILE_SEARCH_DEBOUNCE: Duration = Duration::from_millis(100);
+
+const ACTIVE_SEARCH_COMPLETE_POLL_INTERVAL: Duration = Duration::from_millis(20);
+
+/// State machine for file-search orchestration.
+pub(crate) struct FileSearchManager {
+    /// Unified state guarded by one mutex.
+    state: Arc<Mutex<SearchState>>,
+
+    search_dir: PathBuf,
+    app_tx: AppEventSender,
+}
+
+struct SearchState {
+    /// Latest query typed by user (updated every keystroke).
+    latest_query: String,
+
+    /// true if a search is currently scheduled.
+    is_search_scheduled: bool,
+
+    /// If there is an active search, this will be the query being searched.
+    active_search: Option<ActiveSearch>,
+}
+
+struct ActiveSearch {
+    query: String,
+    cancellation_token: Arc<AtomicBool>,
+}
+
+impl FileSearchManager {
+    pub fn new(search_dir: PathBuf, tx: AppEventSender) -> Self {
+        Self {
+            state: Arc::new(Mutex::new(SearchState {
+                latest_query: String::new(),
+                is_search_scheduled: false,
+                active_search: None,
+            })),
+            search_dir,
+            app_tx: tx,
+        }
+    }
+
+    /// Call whenever the user edits the `@` token.
+    pub fn on_user_query(&self, query: String) {
+        {
+            #[allow(clippy::unwrap_used)]
+            let mut st = self.state.lock().unwrap();
+            if query == st.latest_query {
+                // No change, nothing to do.
+                return;
+            }
+
+            // Update latest query.
+            st.latest_query.clear();
+            st.latest_query.push_str(&query);
+
+            // If there is an in-flight search that is definitely obsolete,
+            // cancel it now.
+            if let Some(active_search) = &st.active_search {
+                if !query.starts_with(&active_search.query) {
+                    active_search
+                        .cancellation_token
+                        .store(true, Ordering::Relaxed);
+                    st.active_search = None;
+                }
+            }
+
+            // Schedule a search to run after debounce.
+            if !st.is_search_scheduled {
+                st.is_search_scheduled = true;
+            } else {
+                return;
+            }
+        }
+
+        // If we are here, we set `st.is_search_scheduled = true` before
+        // dropping the lock. This means we are the only thread that can spawn a
+        // debounce timer.
+        let state = self.state.clone();
+        let search_dir = self.search_dir.clone();
+        let tx_clone = self.app_tx.clone();
+        thread::spawn(move || {
+            // Always do a minimum debounce, but then poll until the
+            // `active_search` is cleared.
+            thread::sleep(FILE_SEARCH_DEBOUNCE);
+            loop {
+                #[allow(clippy::unwrap_used)]
+                if state.lock().unwrap().active_search.is_none() {
+                    break;
+                }
+                thread::sleep(ACTIVE_SEARCH_COMPLETE_POLL_INTERVAL);
+            }
+
+            // The debounce timer has expired, so start a search using the
+            // latest query.
+            let cancellation_token = Arc::new(AtomicBool::new(false));
+            let token = cancellation_token.clone();
+            let query = {
+                #[allow(clippy::unwrap_used)]
+                let mut st = state.lock().unwrap();
+                let query = st.latest_query.clone();
+                st.is_search_scheduled = false;
+                st.active_search = Some(ActiveSearch {
+                    query: query.clone(),
+                    cancellation_token: token,
+                });
+                query
+            };
+
+            FileSearchManager::spawn_file_search(
+                query,
+                search_dir,
+                tx_clone,
+                cancellation_token,
+                state,
+            );
+        });
+    }
+
+    fn spawn_file_search(
+        query: String,
+        search_dir: PathBuf,
+        tx: AppEventSender,
+        cancellation_token: Arc<AtomicBool>,
+        search_state: Arc<Mutex<SearchState>>,
+    ) {
+        std::thread::spawn(move || {
+            let matches = file_search::run(
+                &query,
+                MAX_FILE_SEARCH_RESULTS,
+                &search_dir,
+                Vec::new(),
+                NUM_FILE_SEARCH_THREADS,
+                cancellation_token.clone(),
+            )
+            .map(|res| {
+                res.matches
+                    .into_iter()
+                    .map(|(_, p)| p)
+                    .collect::<Vec<String>>()
+            })
+            .unwrap_or_default();
+
+            let is_cancelled = cancellation_token.load(Ordering::Relaxed);
+            if !is_cancelled {
+                tx.send(AppEvent::FileSearchResult { query, matches });
+            }
+
+            // Reset the active search state. Do a pointer comparison to verify
+            // that we are clearing the ActiveSearch that corresponds to the
+            // cancellation token we were given.
+            {
+                #[allow(clippy::unwrap_used)]
+                let mut st = search_state.lock().unwrap();
+                if let Some(active_search) = &st.active_search {
+                    if Arc::ptr_eq(&active_search.cancellation_token, &cancellation_token) {
+                        st.active_search = None;
+                    }
+                }
+            }
+        });
+    }
+}

--- a/codex-rs/tui/src/file_search.rs
+++ b/codex-rs/tui/src/file_search.rs
@@ -165,7 +165,7 @@ impl FileSearchManager {
         cancellation_token: Arc<AtomicBool>,
         search_state: Arc<Mutex<SearchState>>,
     ) {
-        let compute_indices = false;
+        let compute_indices = true;
         std::thread::spawn(move || {
             let matches = file_search::run(
                 &query,
@@ -176,12 +176,7 @@ impl FileSearchManager {
                 cancellation_token.clone(),
                 compute_indices,
             )
-            .map(|res| {
-                res.matches
-                    .into_iter()
-                    .map(|m| m.path)
-                    .collect::<Vec<String>>()
-            })
+            .map(|res| res.matches)
             .unwrap_or_default();
 
             let is_cancelled = cancellation_token.load(Ordering::Relaxed);

--- a/codex-rs/tui/src/file_search.rs
+++ b/codex-rs/tui/src/file_search.rs
@@ -165,6 +165,7 @@ impl FileSearchManager {
         cancellation_token: Arc<AtomicBool>,
         search_state: Arc<Mutex<SearchState>>,
     ) {
+        let compute_indices = false;
         std::thread::spawn(move || {
             let matches = file_search::run(
                 &query,
@@ -173,11 +174,12 @@ impl FileSearchManager {
                 Vec::new(),
                 NUM_FILE_SEARCH_THREADS,
                 cancellation_token.clone(),
+                compute_indices,
             )
             .map(|res| {
                 res.matches
                     .into_iter()
-                    .map(|(_, p)| p)
+                    .map(|m| m.path)
                     .collect::<Vec<String>>()
             })
             .unwrap_or_default();

--- a/codex-rs/tui/src/get_git_diff.rs
+++ b/codex-rs/tui/src/get_git_diff.rs
@@ -1,0 +1,114 @@
+//! Utility to compute the current Git diff for the working directory.
+//!
+//! The implementation mirrors the behaviour of the TypeScript version in
+//! `codex-cli`: it returns the diff for tracked changes as well as any
+//! untracked files. When the current directory is not inside a Git
+//! repository, the function returns `Ok((false, String::new()))`.
+
+use std::io;
+use std::path::Path;
+use std::process::Command;
+use std::process::Stdio;
+
+/// Return value of [`get_git_diff`].
+///
+/// * `bool` – Whether the current working directory is inside a Git repo.
+/// * `String` – The concatenated diff (may be empty).
+pub(crate) fn get_git_diff() -> io::Result<(bool, String)> {
+    // First check if we are inside a Git repository.
+    if !inside_git_repo()? {
+        return Ok((false, String::new()));
+    }
+
+    // 1. Diff for tracked files.
+    let tracked_diff = run_git_capture_diff(&["diff", "--color"])?;
+
+    // 2. Determine untracked files.
+    let untracked_output = run_git_capture_stdout(&["ls-files", "--others", "--exclude-standard"])?;
+
+    let mut untracked_diff = String::new();
+    let null_device: &Path = if cfg!(windows) {
+        Path::new("NUL")
+    } else {
+        Path::new("/dev/null")
+    };
+
+    for file in untracked_output
+        .split('\n')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        // Use `git diff --no-index` to generate a diff against the null device.
+        let args = [
+            "diff",
+            "--color",
+            "--no-index",
+            "--",
+            null_device.to_str().unwrap_or("/dev/null"),
+            file,
+        ];
+
+        match run_git_capture_diff(&args) {
+            Ok(diff) => untracked_diff.push_str(&diff),
+            // If the file disappeared between ls-files and diff we ignore the error.
+            Err(err) if err.kind() == io::ErrorKind::NotFound => {}
+            Err(err) => return Err(err),
+        }
+    }
+
+    Ok((true, format!("{}{}", tracked_diff, untracked_diff)))
+}
+
+/// Helper that executes `git` with the given `args` and returns `stdout` as a
+/// UTF-8 string. Any non-zero exit status is considered an *error*.
+fn run_git_capture_stdout(args: &[&str]) -> io::Result<String> {
+    let output = Command::new("git")
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .output()?;
+
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+    } else {
+        Err(io::Error::other(format!(
+            "git {:?} failed with status {}",
+            args, output.status
+        )))
+    }
+}
+
+/// Like [`run_git_capture_stdout`] but treats exit status 1 as success and
+/// returns stdout. Git returns 1 for diffs when differences are present.
+fn run_git_capture_diff(args: &[&str]) -> io::Result<String> {
+    let output = Command::new("git")
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .output()?;
+
+    if output.status.success() || output.status.code() == Some(1) {
+        Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+    } else {
+        Err(io::Error::other(format!(
+            "git {:?} failed with status {}",
+            args, output.status
+        )))
+    }
+}
+
+/// Determine if the current directory is inside a Git repository.
+fn inside_git_repo() -> io::Result<bool> {
+    let status = Command::new("git")
+        .args(["rev-parse", "--is-inside-work-tree"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+
+    match status {
+        Ok(s) if s.success() => Ok(true),
+        Ok(_) => Ok(false),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(false), // git not installed
+        Err(e) => Err(e),
+    }
+}

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -6,6 +6,7 @@ use crate::text_formatting::format_and_truncate_tool_result;
 use base64::Engine;
 use codex_ansi_escape::ansi_escape_line;
 use codex_common::elapsed::format_duration;
+use codex_common::summarize_sandbox_policy;
 use codex_core::WireApi;
 use codex_core::config::Config;
 use codex_core::model_supports_reasoning_summaries;
@@ -152,7 +153,7 @@ impl HistoryCell {
                 ("model", config.model.clone()),
                 ("provider", config.model_provider_id.clone()),
                 ("approval", format!("{:?}", config.approval_policy)),
-                ("sandbox", format!("{:?}", config.sandbox_policy)),
+                ("sandbox", summarize_sandbox_policy(&config.sandbox_policy)),
             ];
             if config.model_provider.wire_api == WireApi::Responses
                 && model_supports_reasoning_summaries(&config.model)

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -104,6 +104,9 @@ pub(crate) enum HistoryCell {
     /// Background event.
     BackgroundEvent { view: TextBlock },
 
+    /// Output from the `/diff` command.
+    GitDiffOutput { view: TextBlock },
+
     /// Error event from the backend.
     ErrorEvent { view: TextBlock },
 
@@ -453,9 +456,25 @@ impl HistoryCell {
     pub(crate) fn new_background_event(message: String) -> Self {
         let mut lines: Vec<Line<'static>> = Vec::new();
         lines.push(Line::from("event".dim()));
-        lines.extend(message.lines().map(|l| Line::from(l.to_string()).dim()));
+        lines.extend(message.lines().map(|line| ansi_escape_line(line).dim()));
         lines.push(Line::from(""));
         HistoryCell::BackgroundEvent {
+            view: TextBlock::new(lines),
+        }
+    }
+
+    pub(crate) fn new_diff_output(message: String) -> Self {
+        let mut lines: Vec<Line<'static>> = Vec::new();
+        lines.push(Line::from("/diff".magenta()));
+
+        if message.trim().is_empty() {
+            lines.push(Line::from("No changes detected.".italic()));
+        } else {
+            lines.extend(message.lines().map(ansi_escape_line));
+        }
+
+        lines.push(Line::from(""));
+        HistoryCell::GitDiffOutput {
             view: TextBlock::new(lines),
         }
     }
@@ -549,6 +568,7 @@ impl CellWidget for HistoryCell {
             | HistoryCell::AgentMessage { view }
             | HistoryCell::AgentReasoning { view }
             | HistoryCell::BackgroundEvent { view }
+            | HistoryCell::GitDiffOutput { view }
             | HistoryCell::ErrorEvent { view }
             | HistoryCell::SessionInfo { view }
             | HistoryCell::CompletedExecCommand { view }
@@ -570,6 +590,7 @@ impl CellWidget for HistoryCell {
             | HistoryCell::AgentMessage { view }
             | HistoryCell::AgentReasoning { view }
             | HistoryCell::BackgroundEvent { view }
+            | HistoryCell::GitDiffOutput { view }
             | HistoryCell::ErrorEvent { view }
             | HistoryCell::SessionInfo { view }
             | HistoryCell::CompletedExecCommand { view }

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -48,11 +48,11 @@ pub use cli::Cli;
 pub fn run_main(cli: Cli, codex_linux_sandbox_exe: Option<PathBuf>) -> std::io::Result<()> {
     let (sandbox_policy, approval_policy) = if cli.full_auto {
         (
-            Some(SandboxPolicy::new_full_auto_policy()),
+            Some(SandboxPolicy::new_workspace_write_policy()),
             Some(AskForApproval::OnFailure),
         )
     } else {
-        let sandbox_policy = cli.sandbox.permissions.clone().map(Into::into);
+        let sandbox_policy = None;
         (sandbox_policy, cli.approval_policy.map(Into::into))
     };
 

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -29,6 +29,7 @@ mod citation_regex;
 mod cli;
 mod conversation_history_widget;
 mod exec_command;
+mod get_git_diff;
 mod git_warning_screen;
 mod history_cell;
 mod log_layer;

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -29,6 +29,7 @@ mod citation_regex;
 mod cli;
 mod conversation_history_widget;
 mod exec_command;
+mod file_search;
 mod get_git_diff;
 mod git_warning_screen;
 mod history_cell;

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -51,6 +51,11 @@ pub fn run_main(cli: Cli, codex_linux_sandbox_exe: Option<PathBuf>) -> std::io::
             Some(SandboxPolicy::new_workspace_write_policy()),
             Some(AskForApproval::OnFailure),
         )
+    } else if cli.dangerously_bypass_approvals_and_sandbox {
+        (
+            Some(SandboxPolicy::DangerFullAccess),
+            Some(AskForApproval::Never),
+        )
     } else {
         let sandbox_policy = None;
         (sandbox_policy, cli.approval_policy.map(Into::into))

--- a/codex-rs/tui/src/slash_command.rs
+++ b/codex-rs/tui/src/slash_command.rs
@@ -1,7 +1,5 @@
-use std::collections::HashMap;
-
 use strum::IntoEnumIterator;
-use strum_macros::AsRefStr; // derive macro
+use strum_macros::AsRefStr;
 use strum_macros::EnumIter;
 use strum_macros::EnumString;
 use strum_macros::IntoStaticStr;
@@ -12,9 +10,12 @@ use strum_macros::IntoStaticStr;
 )]
 #[strum(serialize_all = "kebab-case")]
 pub enum SlashCommand {
+    // DO NOT ALPHA-SORT! Enum order is presentation order in the popup, so
+    // more frequently used commands should be listed first.
     New,
-    ToggleMouseMode,
+    Diff,
     Quit,
+    ToggleMouseMode,
 }
 
 impl SlashCommand {
@@ -26,6 +27,9 @@ impl SlashCommand {
                 "Toggle mouse mode (enable for scrolling, disable for text selection)"
             }
             SlashCommand::Quit => "Exit the application.",
+            SlashCommand::Diff => {
+                "Show git diff of the working directory (including untracked files)"
+            }
         }
     }
 
@@ -36,7 +40,7 @@ impl SlashCommand {
     }
 }
 
-/// Return all built-in commands in a HashMap keyed by their command string.
-pub fn built_in_slash_commands() -> HashMap<&'static str, SlashCommand> {
+/// Return all built-in commands in a Vec paired with their command string.
+pub fn built_in_slash_commands() -> Vec<(&'static str, SlashCommand)> {
     SlashCommand::iter().map(|c| (c.command(), c)).collect()
 }


### PR DESCRIPTION
This pull request introduces multiple changes across the codebase, focusing on updates to development environments, CI/CD workflows, provider-specific functionality, and sandbox-related features. Below is a summary of the most important changes grouped by theme.

### Development Environment Updates:
* Updated `.devcontainer/Dockerfile` to use `ubuntu:24.04` instead of `ubuntu:22.04`. Removed custom user creation logic as the new base image includes a pre-created `ubuntu` user. Added `just` to the list of installed packages and included `clippy` and `rustfmt` components for Rust development. [[1]](diffhunk://#diff-13bd9d7a30bf46656bc81f1ad5b908a627f9247be3f7d76df862b0578b534fc6L1-R1) [[2]](diffhunk://#diff-13bd9d7a30bf46656bc81f1ad5b908a627f9247be3f7d76df862b0578b534fc6L14-R25)
* Modified `.devcontainer/devcontainer.json` to set the `remoteUser` to `ubuntu` and adjusted formatting of the `extensions` array.

### CI/CD Workflow Enhancements:
* Enhanced `.github/workflows/ci.yml` by adding checks for `README.md` files in the `codex-cli` directory, ensuring ASCII and Unicode compliance, and validating the table of contents.
* Updated `.github/workflows/rust-release.yml` to support additional tag formats (e.g., alpha/beta versions) and restructured the release process to dynamically define release names based on tags. Removed redundant environment variables and switched the `runs-on` setting to `ubuntu-latest`. [[1]](diffhunk://#diff-14b82e0710ee69627bccc9a780c175ad091f21f9ad4e2072818e4a5a4c870060L18-L20) [[2]](diffhunk://#diff-14b82e0710ee69627bccc9a780c175ad091f21f9ad4e2072818e4a5a4c870060L36-R34) [[3]](diffhunk://#diff-14b82e0710ee69627bccc9a780c175ad091f21f9ad4e2072818e4a5a4c870060L163-R160) [[4]](diffhunk://#diff-14b82e0710ee69627bccc9a780c175ad091f21f9ad4e2072818e4a5a4c870060L175-R182) [[5]](diffhunk://#diff-14b82e0710ee69627bccc9a780c175ad091f21f9ad4e2072818e4a5a4c870060L187-R192)

### Provider-Specific Functionality:
* Extended `codex-cli/src/cli.tsx` to support provider-specific API keys for non-OpenAI providers like Azure and Gemini. Added logic to handle provider-specific authentication flows and error messages. [[1]](diffhunk://#diff-d0c60208d61213d8f02913352d9a3ae13f3e4a9594cd67fcf75ffee3b8c02160R48) [[2]](diffhunk://#diff-d0c60208d61213d8f02913352d9a3ae13f3e4a9594cd67fcf75ffee3b8c02160R331-R345) [[3]](diffhunk://#diff-d0c60208d61213d8f02913352d9a3ae13f3e4a9594cd67fcf75ffee3b8c02160L343-R368) [[4]](diffhunk://#diff-d0c60208d61213d8f02913352d9a3ae13f3e4a9594cd67fcf75ffee3b8c02160R401-R405)
* Updated `codex-cli/src/utils/agent/agent-loop.ts` to ensure the `/responses` endpoint is correctly called when the provider is set to Azure. [[1]](diffhunk://#diff-b15957eac2720c3f1f55aa32f172cdd0ac6969caf4e7be87983df747a9f97083L803-R804) [[2]](diffhunk://#diff-b15957eac2720c3f1f55aa32f172cdd0ac6969caf4e7be87983df747a9f97083L1191-R1193)
* Adjusted `codex-cli/src/utils/config.ts` to update the default Azure API version to `2025-04-01-preview`.
* Added a new test file `codex-cli/tests/agent-azure-responses-endpoint.test.ts` to verify Azure-specific functionality in the `AgentLoop` class.

### Sandbox-Related Updates:
* Removed the `SandboxPermissionOption` from sandbox-related command definitions and logic in `codex-rs/cli/src/debug_sandbox.rs` and `codex-rs/cli/src/lib.rs`. Simplified sandbox policy creation by removing permission-based logic. [[1]](diffhunk://#diff-2165f811f08caa8d93d368465e487ff7bbf5d6ef93ac0c52883503b5139d0641L4) [[2]](diffhunk://#diff-2165f811f08caa8d93d368465e487ff7bbf5d6ef93ac0c52883503b5139d0641L23-L29) [[3]](diffhunk://#diff-2165f811f08caa8d93d368465e487ff7bbf5d6ef93ac0c52883503b5139d0641L44-L50) [[4]](diffhunk://#diff-2165f811f08caa8d93d368465e487ff7bbf5d6ef93ac0c52883503b5139d0641L66-R66) [[5]](diffhunk://#diff-2165f811f08caa8d93d368465e487ff7bbf5d6ef93ac0c52883503b5139d0641L113-R111) [[6]](diffhunk://#diff-1f7034d5b8655e5c40067dcba3864b969e9b97cf0c5b30ab7173a93a0fda1ea1L8-L18) [[7]](diffhunk://#diff-1f7034d5b8655e5c40067dcba3864b969e9b97cf0c5b30ab7173a93a0fda1ea1L33-L35)

### Other Updates:
* Added the `file-search` crate to `codex-rs/Cargo.toml` and enabled `codegen-units = 1` for improved binary optimization. [[1]](diffhunk://#diff-0bdae88bd97e81cd45380b938721a8f794e618c58068084da1fc4e4d52406c3bR11) [[2]](diffhunk://#diff-0bdae88bd97e81cd45380b938721a8f794e618c58068084da1fc4e4d52406c3bR40-R42)
* Introduced a new feature flag `sandbox_summary` in `codex-rs/common/Cargo.toml`.
* Simplified `codex-rs/common/src/approval_mode_cli_arg.rs` by removing unused sandbox-related options and adding a new `Untrusted` approval mode.